### PR TITLE
Switch from shortest to longest index first for novaseq

### DIFF
--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -54,8 +54,8 @@ for RUN_DIR in ${IN_DIR}/*; do
             date +'%Y%m%d%H%M%S' > ${RUN_DIR}/demuxstarted.txt
 
             if [[ ! -e ${RUN_DIR}/SampleSheet.csv ]]; then
-                log "demux sheet fetch --application nova --shortest ${FC} > ${RUN_DIR}/SampleSheet.csv"
-                demux sheet fetch --application nova --shortest ${FC} > ${RUN_DIR}/SampleSheet.csv
+                log "demux sheet fetch --application nova --longest ${FC} > ${RUN_DIR}/SampleSheet.csv"
+                demux sheet fetch --application nova --longest ${FC} > ${RUN_DIR}/SampleSheet.csv
             fi
 
             log "mkdir -p ${DEMUXES_DIR}/${RUN}/"


### PR DESCRIPTION
How to test:

1. ssh thalamus
1. install on stage/dev
1. run `demux sheet fetch -a nova --longest HF32VDMXX`

Expected outcome:
- 16+ length indexes in the sheet :)