### PR TITLE
fix renaming of non-existing fastq files in projects

### DIFF
--- a/scripts/novaseq/demux-novaseq.bash
+++ b/scripts/novaseq/demux-novaseq.bash
@@ -61,7 +61,10 @@ for PROJECT_DIR in ${OUT_DIR}/${UNALIGNED_DIR}/*; do
     if [[ ${PROJECT} == 'Stats' ]]; then continue; fi
     if [[ ${PROJECT} == 'Reports' ]]; then continue; fi
     if [[ ${PROJECT} =~ Project_* ]]; then continue; fi
-    if [[ ${PROJECT} == 'indexcheck' ]]; then mv ${PROJECT_DIR} ${OUT_DIR}/${UNALIGNED_DIR}/Project_${PROJECT}; fi
+    if [[ ${PROJECT} == 'indexcheck' ]]; then
+        mv ${PROJECT_DIR} ${OUT_DIR}/${UNALIGNED_DIR}/Project_${PROJECT}
+        continue
+    fi
 
     for SAMPLE_DIR in ${PROJECT_DIR}/*; do
         for FASTQ_FILE in ${SAMPLE_DIR}/*; do

--- a/scripts/novaseq/demux-novaseq.bash
+++ b/scripts/novaseq/demux-novaseq.bash
@@ -61,6 +61,7 @@ for PROJECT_DIR in ${OUT_DIR}/${UNALIGNED_DIR}/*; do
     if [[ ${PROJECT} == 'Stats' ]]; then continue; fi
     if [[ ${PROJECT} == 'Reports' ]]; then continue; fi
     if [[ ${PROJECT} =~ Project_* ]]; then continue; fi
+    if [[ ${PROJECT} == 'indexcheck' ]]; then mv ${PROJECT_DIR} ${OUT_DIR}/${UNALIGNED_DIR}/Project_${PROJECT}; fi
 
     for SAMPLE_DIR in ${PROJECT_DIR}/*; do
         for FASTQ_FILE in ${SAMPLE_DIR}/*; do


### PR DESCRIPTION
Fixes error during post processing and renaming of files when a sample has zero reads and no fastq-file is created by bcl2fastq.

How to test:
1. clone on thalamus and comment out everything that has to do with demulitplexing or cgstats in the demux-novaseq.bash
2. `rm /home/hiseq.clinical/STAGE/novaseq/runs/181207_A00187_0091_AH3CJ3DRXX/demuxstarted.txt`
2.5 (if needed) `mv /home/hiseq.clinical/STAGE/novaseq/demux/181207_A00187_0091_AH3CJ3DRXX/Unaligned-Y151I8I8Y151/Project_indexcheck /home/hiseq.clinical/STAGE/novaseq/demux/181207_A00187_0091_AH3CJ3DRXX/Unaligned-Y151I8I8Y151/indexcheck`
3. `bash checkfornewrun.bash /home/hiseq.clinical/STAGE/novaseq/runs /home/hiseq.clinical/STAGE/novaseq/demux`

Expected outcome:
No errors while running and /home/hiseq.clinical/STAGE/novaseq/demux/181207_A00187_0091_AH3CJ3DRXX/Unaligned-Y151I8I8Y151/ contains `Project_indexcheck` and NOT `indexcheck`

