### PR TITLE
Sync to rasta and hasta from thalamus

### DIFF
--- a/scripts/2-hiseq-deliver.bash
+++ b/scripts/2-hiseq-deliver.bash
@@ -53,7 +53,7 @@ for RUNDIR in ${INDIR}/*; do
     if [[ ! -e ${RUNDIR}/copycomplete.txt ]]; then
         date +'%Y%m%d%H%M%S' > ${RUNDIR}/copycomplete.txt
         log "rsync -a ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}"
-        rsync -a --progress --exclude=copycomplete.txt ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}
+        rsync -rvt --progress --exclude=copycomplete.txt ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}
         log "scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER}:${TARGET_DIR}/${RUN}/"
         scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER}:${TARGET_DIR}/${RUN}/
         log "ssh ${TARGET_SERVER} 'rm ${TARGET_DIR}/${RUN}/delivery.txt'"
@@ -62,7 +62,7 @@ for RUNDIR in ${INDIR}/*; do
             log "column -t ${RUNDIR}/stats-* | mail -s 'DEMUX ${RUN} delivered to ${TARGET_SERVER}' ${EMAILS}"
             column -t ${RUNDIR}/stats-* | mail -s "DEMUX ${RUN} deliverd to ${TARGET_SERVER}" ${EMAILS}
         fi
-        rsync -a --progress --exclude=copycomplete.txt ${RUNDIR} ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}
+        rsync -rvt --progress --exclude=copycomplete.txt ${RUNDIR} ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}
         log "scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}/${RUN}/"
         scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}/${RUN}/
         if [[ -n ${EMAILS} ]]; then


### PR DESCRIPTION
Some improvements over previous edition:
- if the transfer fails for any reason, remove the copycomplete.txt so the transfer starts again on next crontab iteration. Helps mitigate network failures.
- Send an email as soon as rasta transfer is finished. Send another when hasta transfer is finished.

How to test:
0. Install this branch in a local repo on thalamus: ~/git/demultiplexing
1. This one is configuration heavy, so
  - change the destination of TARGET_DIR_HASTA= to /home/proj/stage/demultiplexed-runs
  - change the EMAILS= to your email address.
2. remove `~/STAGE/novaseq/demux/181207_A00187_0091_AH3CJ3DRXX/copycomplete.txt`
3. `bash ~/git/demulitplexing/scripts/2-hiseq-deliver.bash ~/STAGE//novaseq/demux/181207_A00187_0091_AH3CJ3DRXX rasta /mnt/hds/proj/bioinfo/STAGE/DEMUX/`
4. while this is running: cancel (hit ctrl+c): you should get an email that transfer failed. `~/STAGE/novaseq/demux/181207_A00187_0091_AH3CJ3DRXX/copycomplete.txt` should not exist.
5.  `bash ~/git/demulitplexing/scripts/2-hiseq-deliver.bash ~/STAGE//novaseq/demux/181207_A00187_0091_AH3CJ3DRXX rasta /mnt/hds/proj/bioinfo/STAGE/DEMUX`

Expected outcome:
1. you should get two emails that transfer is complete: one for rasta one for hasta.
1.  `~/STAGE/novaseq/demux/181207_A00187_0091_AH3CJ3DRXX/copycomplete.txt` should exist.