### PR TITLE
Fix outputting an empty sheet when no index lenght set

### DIFF
--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -94,7 +94,8 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         lims_keys = ['fcid', 'lane', 'sample_id', 'sample_ref', 'index', 'description', 'control', 'recipe', 'operator', 'project']
         header = [ HiSeq2500Samplesheet.header_map[head] for head in lims_keys ]
 
-        raw_samplesheet = [ line for line in raw_samplesheet if indexlength and len(line['index'].replace('-','')) == int(indexlength) ]
+        if indexlength:
+            raw_samplesheet = [ line for line in raw_samplesheet if len(line['index'].replace('-','')) == int(indexlength) ]
         for line in raw_samplesheet:
             line['description'] = line['sample_id']
 


### PR DESCRIPTION
How to test:

1. clone
1. on thalamus, run: `demux sheet fetch -a wes HWWK2BCX2`: out put is empty sheet
1. in your own conda env, install demux, set alias demux to this env
1. run `demux sheet fetch -a wes HWWK2BCX2`: output is now a full sheet