### PR TITLE
add padding option of d8 indexes

### DIFF
--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -68,9 +68,9 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
           delimiter=',', end='\n'):
     """
     Fetch a samplesheet from LIMS.
-    If a flowcell has dual indices of length 10+10 bp as well as 8+8 bp, use the option -p, or
-    --pad to add two bases to length 8 indices (AT for index1, AC for index2). This will ensure
-    that all indices in the sample sheet are of the same length.
+    If a flowcell has dual indices of length 10+10 bp (dual 10) as well as 8+8 bp (dual 8), use
+    the option -p, or --pad to add two bases to length 8 indices (AT for index1, AC for index2).
+    This will ensure that all indices in the sample sheet are of the same length.
     """
 
     def reverse_complement(dna):
@@ -159,11 +159,12 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         if pad and not indexlength:
             click.echo(click.style(f"Please specify an index length when using the pad option!"
                                    f"Use --longest or --indexlength. Nota that padding only works"
-                                   f"in combination with d10 indxes!", fg='red'))
+                                   f"in combination with dual 10 indxes!", fg='red'))
             context.abort()
 
         if pad and indexlength != 20:
-            click.echo(click.style(f"Padding is only allowed in combination with d10 indexes!", fg='red'))
+            click.echo(click.style(f"Padding is only allowed in combination with dual 10 indexes!",
+                                   fg='red'))
             context.abort()
 
         lims_keys = ['fcid', 'lane', 'sample_id', 'sample_ref', 'index', 'index2', 'sample_name',

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -62,9 +62,16 @@ def demux(samplesheet, application, flowcell):
 @click.option('-S', '--shortest', is_flag=True, help='2500 and NovaSeq: only return shortest index')
 @click.option('-d', '--delimiter', default=',', show_default=True, help='column delimiter')
 @click.option('-e', '--end', default='\n', show_default=True, help='line delimiter')
+@click.option('-p', '--pad', is_flag=True, default=False, help='add 2 bases to indices with length 8')
 @click.pass_context
-def fetch(context, flowcell, application, dualindex, indexlength, longest, shortest, delimiter=',', end='\n'):
-    """Fetch a samplesheet from LIMS"""
+def fetch(context, flowcell, application, dualindex, indexlength, longest, shortest, pad,
+          delimiter=',', end='\n'):
+    """
+    Fetch a samplesheet from LIMS.
+    If a flowcell has dual indices of length 10+10 bp as well as 8+8 bp, use the option -p, or
+    --pad to add two bases to length 8 indices (AT for index1, AC for index2). This will ensure
+    that all indices in the sample sheet are of the same length.
+    """
 
     def reverse_complement(dna):
         complement = {'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A'}
@@ -76,6 +83,7 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
 
     lims_api = ClinicalLims(**context.obj['lims'])
     raw_samplesheet = list(lims_api.samplesheet(flowcell))
+
     if len(raw_samplesheet) == 0:
         click.echo(click.style('Samplesheet not found in LIMS!', fg='red'))
         context.abort()
@@ -148,6 +156,16 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
                                    f"only!", fg='red'))
             context.abort()
 
+        if pad and not indexlength:
+            click.echo(click.style(f"Please specify an index length when using the pad option!"
+                                   f"Use --longest or --indexlength. Nota that padding only works"
+                                   f"in combination with d10 indxes!", fg='red'))
+            context.abort()
+
+        if pad and indexlength != 20:
+            click.echo(click.style(f"Padding is only allowed in combination with d10 indexes!", fg='red'))
+            context.abort()
+
         lims_keys = ['fcid', 'lane', 'sample_id', 'sample_ref', 'index', 'index2', 'sample_name',
                      'control', 'recipe', 'operator', 'project']
         header = [Samplesheet.header_map[head] for head in lims_keys]
@@ -183,15 +201,25 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
             raw_samplesheet.extend(added_dummy_samples)
 
         if indexlength:
-            raw_samplesheet = [line for line in raw_samplesheet if len(line['index'].replace('-', '')) == int(indexlength)]
+            # if indexlength == 20 (2 * 10 for dual index), also add indexes of length 16 (2 * 8 for dual
+            # indexes) if the pad option is provided
+            if pad and indexlength == 20:
+                raw_samplesheet = [line for line in raw_samplesheet if
+                                   len(line['index'].replace('-', '')) in (16, 20)]
+            else:
+                raw_samplesheet = [line for line in raw_samplesheet if len(line['index'].replace('-', '')) == int(indexlength)]
 
         for line in raw_samplesheet:
             if '-' in line['index']:
-                index1 = line['index'].split('-')[0]
                 index1, index2 = line['index'].split('-')
+                if pad and len(index1) == 8:
+                    index1 += 'AT'
+                    index2 += 'AC'
                 line['index'] = index1
                 line['index2'] = index2
             else:
+                if pad and len(line['index']) == 8:
+                    line['index'] += 'AT'
                 line['index2'] = ''
 
         # add [section] header


### PR DESCRIPTION
Problem: The new unique dual indexes that CG will use to prepare TGA and microbial samples are 10+10 bp long (d10) while our current unique dual indexes for WGS are only 8+8bp (d8). That means that we need to run demultiplexing of FC with a mix of these index types twice. This take a lot of time and involves manual labour.

Suggested solution:
When we create the samplesheet (demux sheet fetch -a nova flowcell_id) we can add two extra bases to the d8 indexes, so that all samples in a run have d10 indexes for demultiplexing. The bases are static (AT for index1, AC for index2). The adding of these two bases shall henceforth be known as padding ;)

Added option -p or --pad for padding
Added error message in case -p is provided but not indexlength (--shortest, --longest or --indexlength)
Added error message in case -p is provided but indexlength is not 20, since padding should only be used in combination with d10 indexes.

Steps:

1. A raw samplesheet is fteched from LIMS
2. Dummy indexes not already in the raw samplesheet are added to the raw samplesheet
3. If the padding option is provided and d10 indexlength is used, generate raw samplesheet with d8 and d10 indexes
4. Pad the d8 indexes by adding 'AT' if index1 and 'AC' if index2

# TODO: PEP8 refactoring

Also, I think we should clean up the entire fetch method at a later point, it's very messy right now.