### PR TITLE
Rm delivered emails

### DIFF
--- a/scripts/2-hiseq-deliver.bash
+++ b/scripts/2-hiseq-deliver.bash
@@ -9,7 +9,7 @@ VERSION=3.4.3
 # VARS #
 ########
 
-INDIR=${1-/home/clinical/DEMUX/}
+INDIR=${1-/home/hiseq.clinical/DEMUX/}
 TARGET_SERVER=${2-hasta.scilifelab.se}
 TARGET_DIR=${3-/home/proj/production/demultiplexed-runs/}
 TARGET_SERVER_HASTA=rastapopoulos.scilifelab.se

--- a/scripts/2-hiseq-deliver.bash
+++ b/scripts/2-hiseq-deliver.bash
@@ -58,17 +58,9 @@ for RUNDIR in ${INDIR}/*; do
         scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER}:${TARGET_DIR}/${RUN}/
         log "ssh ${TARGET_SERVER} 'rm ${TARGET_DIR}/${RUN}/delivery.txt'"
         ssh ${TARGET_SERVER} "rm -f ${TARGET_DIR}/${RUN}/delivery.txt"
-        if [[ -n ${EMAILS} ]]; then
-            log "column -t ${RUNDIR}/stats-* | mail -s 'DEMUX ${RUN} delivered to ${TARGET_SERVER}' ${EMAILS}"
-            column -t ${RUNDIR}/stats-* | mail -s "DEMUX ${RUN} delivered to ${TARGET_SERVER}" ${EMAILS}
-        fi
         rsync -rvt --progress --exclude=copycomplete.txt ${RUNDIR} ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}
         log "scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}/${RUN}/"
         scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}/${RUN}/
-        if [[ -n ${EMAILS} ]]; then
-            log "column -t ${RUNDIR}/stats-* | mail -s 'DEMUX ${RUN} delivered to ${TARGET_SERVER_HASTA}' ${EMAILS}"
-            column -t ${RUNDIR}/stats-* | mail -s "DEMUX ${RUN} delivered to ${TARGET_SERVER_HASTA}" ${EMAILS}
-        fi
         continue
     fi
 


### PR DESCRIPTION
Removes the emails sent when data is successfully transferred to hasta and rasta.

How to test:
0. install on stage on thalamus:
   `git clone -b rm-delivered-emails https://github.com/Clinical-Genomics/demultiplexing.git ~/git/<yourname>/demux/`
1. disable syncing: `crontab -e` comment out the line after `# delivery 2500 results`
1. `rm /home/hiseq.clinical/DEMUX/190308_D00410_0865_AHWLKTBCX2/copycomplete.txt`
1. run: `bash ~/git/<yourname>/demux/scripts/2-hiseq-deliver.bash`
1. enable syncing again

Expected outcome:
syncing should happen and the output should not mention
`column -t /home/hiseq.clinical/DEMUX//190308_D00410_0865_AHWLKTBCX2/stats-*`
after
`scp /home/hiseq.clinical/DEMUX//190308_D00410_0865_AHWLKTBCX2/copycomplete.txt hasta.scilifelab.se:/home/proj/production/demultiplexed-runs//190308_D00410_0865_AHWLKTBCX2/`