### PR TITLE
Add iSeq retrieval

### DIFF
--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -279,4 +279,4 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         line['sample_name'] = project
 
         # print it!
-        click.echo(delimiter.join([str(line[head]) for head in lims_keys]))
+        click.echo(delimiter.join([str(line.get(head, '')) for head in lims_keys]))

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -1,14 +1,16 @@
-# -*- coding: utf-8 -*-
+""" CLI points for samplesheeet action """
 
 import sys
-import click
 import logging
 import copy
 import csv
 import os
 
+import click
+
 from cglims.api import ClinicalLims, ClinicalSample
-from ..utils import Samplesheet, HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet, MiseqSamplesheet
+from ..utils import Samplesheet, HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet,\
+                    MiseqSamplesheet
 
 log = logging.getLogger(__name__)
 
@@ -54,7 +56,7 @@ def demux(samplesheet, application, flowcell):
 
 @sheet.command()
 @click.argument('flowcell')
-@click.option('-a', '--application', type=click.Choice(['wgs', 'wes', 'nova']), help='application type')
+@click.option('-a', '--application', type=click.Choice(['wgs', 'wes', 'nova', 'iseq']), help='application type')
 @click.option('-i', '--dualindex', is_flag=True, default=False, help='X: force dual index, not used \
               for NovaSeq!')
 @click.option('-l', '--indexlength', default=None, help='2500 and NovaSeq: only return this index length')
@@ -196,6 +198,7 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
 
             raw_samplesheet.extend(added_dummy_samples)
 
+
         if indexlength:
             if pad and int(indexlength) in (16, 20):
                 raw_samplesheet = [line for line in raw_samplesheet if
@@ -209,6 +212,45 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
                 if pad and len(index1) == 8:
                     index1 += 'AT'
                     index2 += 'AC'
+                line['index'] = index1
+                line['index2'] = index2
+            else:
+                if pad and len(line['index']) == 8:
+                    line['index'] += 'AT'
+                line['index2'] = ''
+
+        # add [section] header
+        click.echo('[Data]')
+
+    if application == 'iseq':
+        if dualindex:
+            click.echo(click.style(f"No need to specify dual or single index for iSeq sample "
+                                   f"sheets, please use --shortest, --longest, or --indexlength "
+                                   f"only!", fg='red'))
+            context.abort()
+
+        if pad and not indexlength:
+            click.echo(click.style(f"Please specify an index length when using the pad option!"
+                                   f"Use --longest or --indexlength", fg='red'))
+            context.abort()
+
+        lims_keys = ['fcid', 'lane', 'sample_id', 'sample_ref', 'index', 'index2', 'sample_name',
+                     'control', 'recipe', 'operator', 'project']
+        header = [Samplesheet.header_map[head] for head in lims_keys]
+
+        if indexlength:
+            if pad and int(indexlength) in (16, 20):
+                raw_samplesheet = [line for line in raw_samplesheet if
+                                   len(line['index'].replace('-', '')) in (16, int(indexlength))]
+            else:
+                raw_samplesheet = [line for line in raw_samplesheet if len(line['index'].replace('-', '')) == int(indexlength)]
+
+        for line in raw_samplesheet:
+            if '-' in line['index']:
+                index1, index2 = line['index'].split('-')
+                if pad and len(index1) == 8:
+                    index1 += 'AT'
+                    index2 = 'AC' + index2
                 line['index'] = index1
                 line['index2'] = index2
             else:

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -235,7 +235,7 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
             context.abort()
 
         lims_keys = ['sample_id',
-                     'sample_name',
+                     'sample_id',
                      'sample_plate',
                      'description',
                      'i7_index_id',
@@ -244,9 +244,9 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
                      'index2',
                      'manifest',
                      'genome_folder',
-                     'sample_project',
+                     'sample_name',
                      'sample_well']
-        header = [IseqSamplesheet.header_map[head] for head in lims_keys]
+        header = IseqSamplesheet.header_map.values()
 
         if indexlength:
             if pad and int(indexlength) in (16, 20):
@@ -279,4 +279,4 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         line['sample_name'] = project
 
         # print it!
-        click.echo(delimiter.join([str(line.get(head, '')) for head in lims_keys]))
+        click.echo(delimiter.join([str(line.get(lims_key, '')) for lims_key in lims_keys]))

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -236,17 +236,17 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
 
         lims_keys = ['sample_id',
                      'sample_name',
-                     'Sample_Plate',
-                     'Description',
-                     'I7_Index_ID',
+                     'sample_plate',
+                     'description',
+                     'i7_index_id',
                      'index',
-                     'I5_Index_ID',
+                     'i5_index_id',
                      'index2',
-                     'Manifest',
-                     'GenomeFolder',
-                     'Sample_Project',
-                     'Sample_Well']
-        header = [Samplesheet.header_map[head] for head in lims_keys]
+                     'manifest',
+                     'genome_folder',
+                     'sample_project',
+                     'sample_well']
+        header = [IseqSamplesheet.header_map[head] for head in lims_keys]
 
         if indexlength:
             if pad and int(indexlength) in (16, 20):

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -272,6 +272,9 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
                 line['index2'] = ''
 
         # add [section] header
+        click.echo('[Header]')
+        click.echo('[Reads]')
+        click.echo('30')
         click.echo('[Data]')
 
     click.echo(delimiter.join(header))

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -237,7 +237,7 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         lims_keys = ['sample_id',
                      'sample_id',
                      'sample_plate',
-                     'description',
+                     'sample_id',
                      'i7_index_id',
                      'index',
                      'i5_index_id',

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -294,4 +294,4 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         line['sample_name'] = project
 
         # print it!
-        click.echo(delimiter.join([str(line.get(lims_key, '')) for lims_key in lims_keys]))
+        click.echo(delimiter.join([str(line[lims_key]) for lims_key in lims_keys]))

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -10,7 +10,7 @@ import click
 
 from cglims.api import ClinicalLims, ClinicalSample
 from ..utils import Samplesheet, HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet,\
-                    MiseqSamplesheet
+                    MiseqSamplesheet, IseqSamplesheet
 
 log = logging.getLogger(__name__)
 

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -83,7 +83,7 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         """ Only keeps the first part of the project name"""
         return project.split(' ')[0]
 
-    lims_api = ClinicalLims(**context.obj['lim s'])
+    lims_api = ClinicalLims(**context.obj['lims'])
     raw_samplesheet = list(lims_api.samplesheet(flowcell))
 
     if len(raw_samplesheet) == 0:

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -83,7 +83,7 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         """ Only keeps the first part of the project name"""
         return project.split(' ')[0]
 
-    lims_api = ClinicalLims(**context.obj['lims'])
+    lims_api = ClinicalLims(**context.obj['lim s'])
     raw_samplesheet = list(lims_api.samplesheet(flowcell))
 
     if len(raw_samplesheet) == 0:
@@ -234,8 +234,18 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
                                    f"Use --longest or --indexlength", fg='red'))
             context.abort()
 
-        lims_keys = ['fcid', 'lane', 'sample_id', 'sample_ref', 'index', 'index2', 'sample_name',
-                     'control', 'recipe', 'operator', 'project']
+        lims_keys = ['sample_id',
+                     'sample_name',
+                     'Sample_Plate',
+                     'Description',
+                     'I7_Index_ID',
+                     'index',
+                     'I5_Index_ID',
+                     'index2',
+                     'Manifest',
+                     'GenomeFolder',
+                     'Sample_Project',
+                     'Sample_Well']
         header = [Samplesheet.header_map[head] for head in lims_keys]
 
         if indexlength:

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -236,30 +236,18 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
 
         lims_keys = ['sample_id',
                      'sample_id',
-                     'sample_plate',
                      'sample_id',
-                     'i7_index_id',
                      'index',
-                     'i5_index_id',
                      'index2',
-                     'manifest',
-                     'genome_folder',
-                     'sample_name',
-                     'sample_well']
+                     'sample_name']
 
         header = [
             'Sample_ID',
             'Sample_Name',
-            'Sample_Plate',
             'Description',
-            'I7_Index_ID',
             'index',
-            'I5_Index_ID',
             'index2',
-            'Manifest',
-            'GenomeFolder',
-            'Sample_Project',
-            'Sample_Well'
+            'Sample_Project'
         ]
 
         if indexlength:

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -253,7 +253,8 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
                 raw_samplesheet = [line for line in raw_samplesheet if
                                    len(line['index'].replace('-', '')) in (16, int(indexlength))]
             else:
-                raw_samplesheet = [line for line in raw_samplesheet if len(line['index'].replace('-', '')) == int(indexlength)]
+                raw_samplesheet = [line for line in raw_samplesheet if len(line['index'].replace(
+                    '-', '')) == int(indexlength)]
 
         for line in raw_samplesheet:
             if '-' in line['index']:

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -10,7 +10,7 @@ import click
 
 from cglims.api import ClinicalLims, ClinicalSample
 from ..utils import Samplesheet, HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet,\
-                    MiseqSamplesheet, IseqSamplesheet
+                    MiseqSamplesheet
 
 log = logging.getLogger(__name__)
 
@@ -246,7 +246,21 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
                      'genome_folder',
                      'sample_name',
                      'sample_well']
-        header = IseqSamplesheet.header_map.values()
+
+        header = [
+            'Sample_ID',
+            'Sample_Name',
+            'Sample_Plate',
+            'Description',
+            'I7_Index_ID',
+            'index',
+            'I5_Index_ID',
+            'index2',
+            'Manifest',
+            'GenomeFolder',
+            'Sample_Project',
+            'Sample_Well'
+        ]
 
         if indexlength:
             if pad and int(indexlength) in (16, 20):

--- a/demux/utils/__init__.py
+++ b/demux/utils/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
-from .samplesheet import Samplesheet, HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet, MiseqSamplesheet, SampleSheetValidationException
+from .samplesheet import Samplesheet, HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet, \
+    MiseqSamplesheet, SampleSheetValidationException, IseqSamplesheet

--- a/demux/utils/__init__.py
+++ b/demux/utils/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from .samplesheet import Samplesheet, HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet, \
-    MiseqSamplesheet, SampleSheetValidationException, IseqSamplesheet
+    MiseqSamplesheet, SampleSheetValidationException

--- a/demux/utils/samplesheet.py
+++ b/demux/utils/samplesheet.py
@@ -640,5 +640,5 @@ class IseqSamplesheet(Samplesheet):
         'manifest': 'Manifest',
         'genome_folder': 'GenomeFolder',
         'sample_project': 'Sample_Project',
-        'sample_well': 'Sample_Well',
+        'sample_well': 'Sample_Well'
     }

--- a/demux/utils/samplesheet.py
+++ b/demux/utils/samplesheet.py
@@ -625,3 +625,20 @@ class NIPTSamplesheet(Samplesheet):
             rs.append(delim.join(line))
         return end.join(rs)
 
+
+class IseqSamplesheet(Samplesheet):
+
+    header_map = {
+        'sample_id': 'Sample_ID',
+        'sample_name': 'Sample_Name',
+        'sample_plate': 'Sample_Plate',
+        'description': 'Description',
+        'i7_index_id': 'I7_Index_ID',
+        'index': 'index',
+        'i5_index_id': 'I5_Index_ID',
+        'index2': 'index2',
+        'manifest': 'Manifest',
+        'genome_folder': 'GenomeFolder',
+        'sample_project': 'Sample_Project',
+        'sample_well': 'Sample_Well',
+    }

--- a/demux/utils/samplesheet.py
+++ b/demux/utils/samplesheet.py
@@ -624,21 +624,3 @@ class NIPTSamplesheet(Samplesheet):
         for line in data_lines:
             rs.append(delim.join(line))
         return end.join(rs)
-
-
-class IseqSamplesheet(Samplesheet):
-
-    header_map = {
-        'sample_id': 'Sample_ID',
-        'sample_name': 'Sample_Name',
-        'sample_plate': 'Sample_Plate',
-        'description': 'Description',
-        'i7_index_id': 'I7_Index_ID',
-        'index': 'index',
-        'i5_index_id': 'I5_Index_ID',
-        'index2': 'index2',
-        'manifest': 'Manifest',
-        'genome_folder': 'GenomeFolder',
-        'sample_project': 'Sample_Project',
-        'sample_well': 'Sample_Well'
-    }


### PR DESCRIPTION
This PR solves the retrieval of the iSeq samplesheet.

**How to test?**
1. `bash update-demux-stage.sh isheet` on clinical-preproc stage.
1. run: `demux sheet fetch -a iseq --pad --indexlength 10 $flowcell`
        with $flowcell BPC29611-2526 or BPC29611-3324 (see comment below)

**Expected outcome**
The fecth command will print the samplesheet to stdout. The samplesheet should contain an index and index2 column. index should end with AT and index2 should start with AC.

Headers should be: 
Sample_Name | Sample_Plate | Description | I7_Index_ID | index | I5_Index_ID | index2 | Manifest | GenomeFolder | Sample_Project | Sample_Well



This is **minor version** bump: extending and not modifying public API.

@emiliaol can you provide a FC id?

- [x] Code reviewed by @ingkebil  
- [x] Tested by @patrikgrenfeldt and @emiliaol 
- [x] Deploy signature @ingkebil 