### PR TITLE
Rm sync to rasta

### DIFF
--- a/scripts/2-hiseq-deliver.bash
+++ b/scripts/2-hiseq-deliver.bash
@@ -12,8 +12,6 @@ VERSION=3.4.3
 INDIR=${1-/home/hiseq.clinical/DEMUX/}
 TARGET_SERVER=${2-hasta.scilifelab.se}
 TARGET_DIR=${3-/home/proj/production/demultiplexed-runs/}
-TARGET_SERVER_HASTA=rastapopoulos.scilifelab.se
-TARGET_DIR_HASTA=/mnt/hds/proj/bioinfo/DEMUX/
 EMAILS=${4-clinical-demux@scilifelab.se}
 
 #############
@@ -58,9 +56,6 @@ for RUNDIR in ${INDIR}/*; do
         scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER}:${TARGET_DIR}/${RUN}/
         log "ssh ${TARGET_SERVER} 'rm ${TARGET_DIR}/${RUN}/delivery.txt'"
         ssh ${TARGET_SERVER} "rm -f ${TARGET_DIR}/${RUN}/delivery.txt"
-        rsync -rvt --progress --exclude=copycomplete.txt ${RUNDIR} ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}
-        log "scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}/${RUN}/"
-        scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER_HASTA}:${TARGET_DIR_HASTA}/${RUN}/
         continue
     fi
 


### PR DESCRIPTION
This PR removes syncing to rasta

How to test:
1. Clone this branch on clinical-preproc: `git clone -b rm-rasa https://github.com/clinical-genomics/demultiplexing.git ~/git/yourname/demultiplexing/
1. Run: `bash ~/git/yourname/demultiplexing/scripts/bash 2-hiseq-deliver.bash ${HOME}/novaseq/demux/ hasta.scilifelab.se /home/proj/production/demultiplexed-runs/ your.name@scilifelab.se`

Expected outcome:
no errors! :)

- [ ] code review skipped
- [x] tested by @ingkebil 
- [x] approved for deploy by @ingkebil 

This is a patch version: hotfix to make sure TEAPOT is not flushed with errors