### PR TITLE
Add account for xpostface

### DIFF
--- a/scripts/hiseqx/xdemuxtiles.bash
+++ b/scripts/hiseqx/xdemuxtiles.bash
@@ -111,8 +111,8 @@ log "Running ${RUNNING_JOBIDS[*]}"
 log "Demux ${DEMUX_JOBIDS[*]}"
 log "Remaining ${REMAINING_JOBIDS[*]}"
 JOB_TITLE="xdem-xpostface-${FC}"
-log "sbatch -J 'Xdem-postface' --dependency='${DEPENDENCY}' -o '${LOGDIR}/${JOB_TITLE}-%j.log' -e '${LOGDIR}/${JOB_TITLE}-%j.err' '${SCRIPTDIR}/xpostface.batch' '${OUTDIR}/'"
-     sbatch -J "Xdem-postface" --dependency="${DEPENDENCY}" -o "${LOGDIR}/${JOB_TITLE}-%j.log" -e "${LOGDIR}/${JOB_TITLE}-%j.err" "${SCRIPTDIR}/xpostface.batch" "${OUTDIR}/"
+log "sbatch -A ${SLURM_ACCOUNT} -J 'Xdem-postface' --dependency='${DEPENDENCY}' -o '${LOGDIR}/${JOB_TITLE}-%j.log' -e '${LOGDIR}/${JOB_TITLE}-%j.err' '${SCRIPTDIR}/xpostface.batch' '${OUTDIR}/'"
+     sbatch -A ${SLURM_ACCOUNT} -J "Xdem-postface" --dependency="${DEPENDENCY}" -o "${LOGDIR}/${JOB_TITLE}-%j.log" -e "${LOGDIR}/${JOB_TITLE}-%j.err" "${SCRIPTDIR}/xpostface.batch" "${OUTDIR}/"
 
 ###########
 # CLEANUP #


### PR DESCRIPTION
This PR fixes the missing slurm Account from the invocation of the `xpostface.sh`

How to test:
1. install with the update script
1. 
        cd /home/proj/stage/flowcells/hiseqx/170630_ST-E00198_0227_AH2GL2CCXY
        rm demuxstarted.txt
        bash /home/proj/stage/bin/git/demultiplexing/scripts/hiseqx/xcheckfornewrun.bash

Expected outcome:
The script should submit all scripts without error. Once ocnfirmed, you can scancel all jobs: `scancel -u <youruser>`

- [ ] code review by
- [ ] test done by
- [ ] deploy approved by

This is a patch version bump: fixing a bug