### PR TITLE
Fix: Add overwriting of destination

### DIFF
--- a/scripts/hiseqx/xdemuxtiles.batch
+++ b/scripts/hiseqx/xdemuxtiles.batch
@@ -130,8 +130,8 @@ for PROJECT_DIR in "${TMPOUT_DIR}"/*; do
     # hardlink the project dir as it might already be existing in the target location
     PROJECT_OUTDIR=${OUTDIR}/${UNALIGNED_DIR}/Project_${PROJECT}
     mkdir -p "${PROJECT_OUTDIR}"
-    log "cp -rl '${PROJECT_DIR}'/* '${PROJECT_OUTDIR}'"
-         cp -rl "${PROJECT_DIR}"/* "${PROJECT_OUTDIR}"
+    log "cp -rlf '${PROJECT_DIR}'/* '${PROJECT_OUTDIR}'"
+         cp -rlf "${PROJECT_DIR}"/* "${PROJECT_OUTDIR}"
 done
 
 log "Done copying output"


### PR DESCRIPTION
This PR fixes the jobs failing when the output directory `Unaligned` already exists.

How to test:
1. Install branch with update script on stage
1. run: `rm /home/proj/stage/flowcells/hiseqx/170630_ST-E00198_0227_AH2GL2CCXY/demuxstarted.txt`
1. run: `bash ${PROJECT_HOME}/stage/bin/git/demultiplexing/scripts/hiseqx/xcheckfornewrun.bash ${PROJECT_HOME}/stage/flowcells/hiseqx/ ${PROJECT_HOME}/stage/demultiplexed-runs/`

... aaaha ran out of time!

- [x] code @barrystokman 
- [ ] test
- [ ] deploy