### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+dist: xenial
 language: python
 python:
-    - "2.7"
     - "3.6"
+    - "3.7"
 services:
     - mysql
 


### PR DESCRIPTION
This PR adds python 3.7 to travisCI

**How to test**:
1. Check TravisCI output

**Expected outcome**:
Travis should be rnu on both python 3.6 and 3.7

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because no added functionality.