### PR TITLE
Exclude Undetermined files from rsync

### DIFF
--- a/scripts/2-hiseq-deliver.bash
+++ b/scripts/2-hiseq-deliver.bash
@@ -50,8 +50,8 @@ for RUNDIR in ${INDIR}/*; do
 
     if [[ ! -e ${RUNDIR}/copycomplete.txt ]]; then
         date +'%Y%m%d%H%M%S' > ${RUNDIR}/copycomplete.txt
-        log "rsync -a ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}"
-        rsync -rvt --progress --exclude=copycomplete.txt ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}
+        log "rsync -rt --progress --exclude=copycomplete.txt --exclude=Undetermined* ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}"
+        rsync -rt --progress --exclude=copycomplete.txt --exclude=Undetermined* ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}
         log "scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER}:${TARGET_DIR}/${RUN}/"
         scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER}:${TARGET_DIR}/${RUN}/
         log "ssh ${TARGET_SERVER} 'rm ${TARGET_DIR}/${RUN}/delivery.txt'"

--- a/scripts/2-hiseq-deliver.bash
+++ b/scripts/2-hiseq-deliver.bash
@@ -50,8 +50,8 @@ for RUNDIR in ${INDIR}/*; do
 
     if [[ ! -e ${RUNDIR}/copycomplete.txt ]]; then
         date +'%Y%m%d%H%M%S' > ${RUNDIR}/copycomplete.txt
-        log "rsync -rt --progress --exclude=copycomplete.txt --exclude=Undetermined* ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}"
-        rsync -rt --progress --exclude=copycomplete.txt --exclude=Undetermined* ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}
+        log "rsync -rt --progress --exclude=copycomplete.txt --exclude='Undetermined*' ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}"
+        rsync -rt --progress --exclude=copycomplete.txt --exclude='Undetermined*' ${RUNDIR} ${TARGET_SERVER}:${TARGET_DIR}
         log "scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER}:${TARGET_DIR}/${RUN}/"
         scp ${RUNDIR}/copycomplete.txt ${TARGET_SERVER}:${TARGET_DIR}/${RUN}/
         log "ssh ${TARGET_SERVER} 'rm ${TARGET_DIR}/${RUN}/delivery.txt'"


### PR DESCRIPTION
This PR removes syncing of Undetermined files from thalamus to hasta.

**How to test on thalamus**:
1. On hasta: `rm /home/proj/stage/demultiplexed-runs/190208_A00689_0009_AHHMGWDSXX/Unaligned-Y151I10I10Y151/Undetermined*`

On thalamus:
1. install on locally: `cd ~/git/yourname/; git clone git+https://github.com/clinical-genomics/demultiplexing@exclude`
1. remove the copycomplete.txt files: `rm ~/STAGE/novaseq/demux/*/copycomplete.txt`
1. run following command: `bash /home/hiseq.clinical/git/yourname/demultiplexing/scripts/2-hiseq-deliver.bash /home/hiseq.clinical/STAGE/novaseq/demux/ hasta.scilifelab.se /home/proj/stage/demultiplexed-runs/`

**Expected outcome**:
After a few hours check `hasta.scilifelab.se:/home/proj/stage/demultiplexed-runs/`. Following runs should be synced:
- 190129_A00689_0008_BHHGYWDSXX
- 190208_A00689_0009_AHHMGWDSXX

Neither of these runs should contain Undetermined files in Unaligned-*.

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @ingkebil 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because there is no change in functionality.
