### PR TITLE
Automatic demultiplexing of iseq runs

### DIFF
--- a/demux/utils/__init__.py
+++ b/demux/utils/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from .samplesheet import Samplesheet, HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet, \
-    MiseqSamplesheet, SampleSheetValidationException
+    MiseqSamplesheet, SampleSheetValidationException, iseqSampleSheet

--- a/demux/utils/samplesheet.py
+++ b/demux/utils/samplesheet.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from collections import OrderedDict
 from path import Path
 
+
 class SampleSheetValidationException(Exception):
     def __init__(self, section, msg, line_nr):
         self.section = section
@@ -30,6 +31,7 @@ class Line(dict):
             index2 = _reverse_complement(self['index2']) if revcomp else self['index2']
             return self['index'] + delim + index2
         return self['index']
+
 
 class Samplesheet(object):
     """SampleSheet.
@@ -304,6 +306,14 @@ class HiSeqXSamplesheet(Samplesheet):
                 raise SampleSheetValidationException(self.DATA, rs[1], rs[0])
 
         return True
+
+
+class iseqSampleSheet(Samplesheet):
+
+    header_map = {
+            'sample_id': 'Sample_ID', 'sample_name': 'Sample_Name', 'description': 'Description',
+            'index': 'index', 'index2': 'index2', 'sample_project': 'Sample_Project'
+    }
 
 
 class MiseqSamplesheet(Samplesheet):

--- a/demux/utils/samplesheet.py
+++ b/demux/utils/samplesheet.py
@@ -311,8 +311,9 @@ class HiSeqXSamplesheet(Samplesheet):
 class iseqSampleSheet(Samplesheet):
 
     header_map = {
-            'sample_id': 'Sample_ID', 'sample_name': 'Sample_Name', 'description': 'Description',
-            'index': 'index', 'index2': 'index2', 'project': 'Sample_Project'
+            'fcid': 'FCID', 'sample_id': 'Sample_ID', 'sample_name': 'Sample_Name',
+            'description': 'Description', 'index': 'index', 'index2': 'index2', 'project':
+            'Sample_Project'
     }
 
 

--- a/demux/utils/samplesheet.py
+++ b/demux/utils/samplesheet.py
@@ -89,8 +89,8 @@ class Samplesheet(object):
 
     def _get_data_header(self):
         header_r = self._get_data_header_r()
-        header_map_r = dict((v,k) for k,v in self.header_map.items())
-        header = [ header_map_r[k] for k in header_r ]
+        header_map_r = dict((v, k) for k, v in self.header_map.items())
+        header = [header_map_r[k] for k in header_r]
 
         return header
 
@@ -312,7 +312,7 @@ class iseqSampleSheet(Samplesheet):
 
     header_map = {
             'sample_id': 'Sample_ID', 'sample_name': 'Sample_Name', 'description': 'Description',
-            'index': 'index', 'index2': 'index2', 'sample_project': 'Sample_Project'
+            'index': 'index', 'index2': 'index2', 'project': 'Sample_Project'
     }
 
 

--- a/scripts/iseq/checkfornewrun.bash
+++ b/scripts/iseq/checkfornewrun.bash
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -u
+
+shopt -s nullglob
+shopt -s expand_aliases
+source ~/.aliases
+
+########
+# VARS #
+########
+
+IN_DIR=${1?'please provide the runs dir'}
+DEMUXES_DIR=${2?'please provide the demuxes dir'}
+SCRIPT_DIR=$(dirname $(readlink -nm $0))
+EMAIL=clinical-demux@scilifelab.se
+
+#############
+# FUNCTIONS #
+#############
+
+log () {
+    NOW=$(date +"%Y%m%d%H%M%S")
+    echo [${NOW}] $@
+}
+
+failed() {
+    cat ${PROJECTLOG} | mail -s "ERROR starting iseq ${FC} on $(hostname)" $EMAIL
+}
+trap failed ERR
+
+########
+# MAIN #
+########
+
+if pgrep bcl2fastq; then
+    log "an instance of bcl2fastq is already running -- skipping"
+    exit 0
+fi
+
+for RUN_DIR in ${IN_DIR}/*; do
+    if [[ ! -d ${RUN_DIR} ]]; then
+        continue
+    fi
+
+    RUN=$(basename ${RUN_DIR})
+    FC=${RUN##*_}
+    FC=${FC:1}
+    PROJECTLOG=${DEMUXES_DIR}/${RUN}/projectlog.$(date +'%Y%m%d%H%M%S').log
+
+    if [[ -f ${RUN_DIR}/RTAComplete.txt ]]; then
+        if [[ ! -f ${RUN_DIR}/demuxstarted.txt ]]; then
+            log "date +'%Y%m%d%H%M%S' > ${RUN_DIR}/demuxstarted.txt"
+            date +'%Y%m%d%H%M%S' > ${RUN_DIR}/demuxstarted.txt
+
+            if [[ ! -e ${RUN_DIR}/SampleSheet.csv ]]; then
+                log "demux sheet fetch --application iseq --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv"
+                demux sheet fetch --application iseq --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv
+            fi
+
+            log "mkdir -p ${DEMUXES_DIR}/${RUN}/"
+            mkdir -p ${DEMUXES_DIR}/${RUN}/
+
+            log "bash ${SCRIPT_DIR}/demux-iseq.bash ${RUN_DIR} ${DEMUXES_DIR} &>> ${PROJECTLOG}"
+            bash ${SCRIPT_DIR}/demux-iseq.bash ${RUN_DIR} ${DEMUXES_DIR} &>> ${PROJECTLOG}
+
+            if [[ $? == 0 ]]; then
+                log "rm -f ${DEMUXES_DIR}/${RUN}/copycomplete.txt"
+                rm -f ${DEMUXES_DIR}/${RUN}/copycomplete.txt
+                log "date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/demuxcomplete.txt"
+                date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/demuxcomplete.txt
+            fi
+        else
+            log "${RUN} is finished and demultiplexing has already started"
+        fi
+    else
+        log "${RUN} is not finished yet"
+    fi
+done

--- a/scripts/iseq/demux-iseq.bash
+++ b/scripts/iseq/demux-iseq.bash
@@ -84,8 +84,8 @@ for PROJECT_DIR in ${OUT_DIR}/${UNALIGNED_DIR}/*; do
 done
 
 # Need to add stats code here :)
-log "cgstats add --machine novaseq --unaligned ${UNALIGNED_DIR} ${OUT_DIR}"
-cgstats add --machine novaseq --unaligned ${UNALIGNED_DIR} ${OUT_DIR}
+log "cgstats add --machine iseq --unaligned ${UNALIGNED_DIR} ${OUT_DIR}"
+cgstats add --machine iseq --unaligned ${UNALIGNED_DIR} ${OUT_DIR}
 
 PROJECTS=$(ls ${OUT_DIR}/${UNALIGNED_DIR}/ | grep Project_)
 for PROJECT_DIR in ${PROJECTS[@]}; do

--- a/scripts/iseq/demux-iseq.bash
+++ b/scripts/iseq/demux-iseq.bash
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -eu
+
+shopt -s expand_aliases
+source $HOME/.bashrc
+ulimit -n 4096
+
+##########
+# PARAMS #
+##########
+
+IN_DIR=${1?'please provide a run dir'}
+DEMUXES_DIR=${2?'please provide the demuxes dir'}
+
+RUN=$(basename ${IN_DIR})
+OUT_DIR=${DEMUXES_DIR}/${RUN}
+
+BCL2FASTQ_BIN=/usr/local/bcl2fastq2/bin/bcl2fastq
+
+#############
+# FUNCTIONS #
+#############
+
+log() {
+    local NOW=$(date +"%Y%m%d%H%M%S")
+    echo "[$NOW] $@"
+}
+
+########
+# MAIN #
+########
+
+# init
+mkdir -p ${OUT_DIR}
+
+# log the version
+demux --version
+${BCL2FASTQ_BIN} --version
+
+# Here we go!
+log "Here we go!"
+
+BASEMASK=Y30I10I10
+UNALIGNED_DIR=Unaligned-${BASEMASK//,}
+
+# DEMUX !
+log "${BCL2FASTQ_BIN} --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${IN_DIR} --output-dir ${OUT_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${IN_DIR}/SampleSheet.csv --barcode-mismatches 1"
+${BCL2FASTQ_BIN} --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${IN_DIR} --output-dir ${OUT_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${IN_DIR}/SampleSheet.csv --barcode-mismatches 1
+
+# add samplesheet to unaligned folder
+cp ${IN_DIR}/SampleSheet.csv ${OUT_DIR}/${UNALIGNED_DIR}/
+
+# Restructure the output dir!
+FC=${RUN##*_}
+FC=${FC:1}
+shopt -s nullglob
+for PROJECT_DIR in ${OUT_DIR}/${UNALIGNED_DIR}/*; do
+    if [[ ! -d ${PROJECT_DIR} ]]; then continue; fi
+
+    PROJECT=$(basename ${PROJECT_DIR})
+    if [[ ${PROJECT} == 'Stats' ]]; then continue; fi
+    if [[ ${PROJECT} == 'Reports' ]]; then continue; fi
+    if [[ ${PROJECT} =~ Project_* ]]; then continue; fi
+    if [[ ${PROJECT} == 'indexcheck' ]]; then
+        mv ${PROJECT_DIR} ${OUT_DIR}/${UNALIGNED_DIR}/Project_${PROJECT}
+        continue
+    fi
+
+    for SAMPLE_DIR in ${PROJECT_DIR}/*; do
+        for FASTQ_FILE in ${SAMPLE_DIR}/*; do
+            FASTQ=$(basename ${FASTQ_FILE})
+            log "mv ${FASTQ_FILE} ${SAMPLE_DIR}/${FC}_${FASTQ}"
+            mv ${FASTQ_FILE} ${SAMPLE_DIR}/${FC}_${FASTQ}
+        done
+
+        SAMPLE=$(basename ${SAMPLE_DIR})
+        log "mv ${SAMPLE_DIR} ${PROJECT_DIR}/Sample_${SAMPLE}"
+        mv ${SAMPLE_DIR} ${PROJECT_DIR}/Sample_${SAMPLE}
+    done
+
+    log "mv ${PROJECT_DIR} ${OUT_DIR}/${UNALIGNED_DIR}/Project_${PROJECT}"
+    mv ${PROJECT_DIR} ${OUT_DIR}/${UNALIGNED_DIR}/Project_${PROJECT}
+done
+
+# Need to add stats code here :)
+log "cgstats add --machine novaseq --unaligned ${UNALIGNED_DIR} ${OUT_DIR}"
+cgstats add --machine novaseq --unaligned ${UNALIGNED_DIR} ${OUT_DIR}
+
+PROJECTS=$(ls ${OUT_DIR}/${UNALIGNED_DIR}/ | grep Project_)
+for PROJECT_DIR in ${PROJECTS[@]}; do
+    PROJECT=${PROJECT_DIR##*_}
+    log "cgstats select --project ${PROJECT} ${FC} &> ${OUT_DIR}/stats-${PROJECT}-${FC}.txt"
+    cgstats select --project ${PROJECT} ${FC} &> ${OUT_DIR}/stats-${PROJECT}-${FC}.txt
+done

--- a/scripts/iseq/demux-iseq.bash
+++ b/scripts/iseq/demux-iseq.bash
@@ -41,7 +41,7 @@ ${BCL2FASTQ_BIN} --version
 # Here we go!
 log "Here we go!"
 
-BASEMASK=Y30I10I10
+BASEMASK=Y30,I10,I10
 UNALIGNED_DIR=Unaligned-${BASEMASK//,}
 
 # DEMUX !


### PR DESCRIPTION
This PR adds demuliplexing support for iSeq

**How to setup**:
1. install on stage of thalamus: `bash servers/resources/clinical-preproc.scilifelab.se/update-demux-stage.sh Automatic-demultiplexing-of-iSeq-runs`
1. cd cd /home/hiseq.clinical/SCRIPTS/git/demultiplexing/
1. git pull
1. git checkout Automatic-demultiplexing-of-iSeq-runs
1. activate stage: source activate stage
1. cd /home/hiseq.clinical/SCRIPTS/git/demultiplexing/scripts/iseq/

**How to test demultiplexing**:
1. run following command: ` bash demux-iseq.bash /home/hiseq.clinical/iseq/runs/20190528_FS10000534_7_BPC29611-3324/ /home/hiseq.clinical/iseq/demux/`

**Expected outcome**:
- [x] demultiplexing should start happily

**How to test checking for new run**:
1. run following command: `bash checkfornewrun.bash /home/hiseq.clinical/iseq/runs/ /home/hiseq.clinical/iseq/demux/`

**Expected outcome**:
- [x] all runs without a `demuxstarted.txt` file should start. All other should be mentioned as already demultiplexed.

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil @barrystokman 
- [x] tests executed by @patrikgrenfeldt @emiliaol tested in cgstats iseq [PR ](https://github.com/Clinical-Genomics/cgstats/pull/21)
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is |minor| **version bump** because we add func without altering the old one
