### PR TITLE
Add qos to xdemuxtiles.bash

### DIFF
--- a/scripts/hiseqx/xdemuxtiles.bash
+++ b/scripts/hiseqx/xdemuxtiles.bash
@@ -7,7 +7,7 @@ set -eu -o pipefail
 # PARAMS #
 ##########
 
-VERSION=5.0.1
+VERSION=5.2.1
 RUNDIR=${1?'full path to run dir'}
 OUTDIR=${2-"/home/proj/${ENVIRONMENT}/demultiplexed-runs/$(basename "${RUNDIR}")/"}
 
@@ -111,8 +111,8 @@ log "Running ${RUNNING_JOBIDS[*]}"
 log "Demux ${DEMUX_JOBIDS[*]}"
 log "Remaining ${REMAINING_JOBIDS[*]}"
 JOB_TITLE="xdem-xpostface-${FC}"
-log "sbatch -J 'Xdem-postface' --dependency='${DEPENDENCY}' -o '${LOGDIR}/${JOB_TITLE}-%j.log' -e '${LOGDIR}/${JOB_TITLE}-%j.err' '${SCRIPTDIR}/xpostface.batch' '${OUTDIR}/'"
-     sbatch -J "Xdem-postface" --dependency="${DEPENDENCY}" -o "${LOGDIR}/${JOB_TITLE}-%j.log" -e "${LOGDIR}/${JOB_TITLE}-%j.err" "${SCRIPTDIR}/xpostface.batch" "${OUTDIR}/"
+log "sbatch -A ${SLURM_ACCOUNT} -J 'Xdem-postface' --dependency='${DEPENDENCY}' -o '${LOGDIR}/${JOB_TITLE}-%j.log' -e '${LOGDIR}/${JOB_TITLE}-%j.err' '${SCRIPTDIR}/xpostface.batch' '${OUTDIR}/'"
+     sbatch -A ${SLURM_ACCOUNT} -J "Xdem-postface" --dependency="${DEPENDENCY}" -o "${LOGDIR}/${JOB_TITLE}-%j.log" -e "${LOGDIR}/${JOB_TITLE}-%j.err" "${SCRIPTDIR}/xpostface.batch" "${OUTDIR}/"
 
 ###########
 # CLEANUP #


### PR DESCRIPTION
This PR fixes the missing account for the post-script, which at this point fails the demux. It seems like I (I guess?) had patched this quickly in production a while ago (foei foei foei!), so this is the PR to actually make those changes official and tested.

**How to test**:
1. install on stage
1. activate stage: `us`
1. run following command: `bash xdemuxtiles.bash /home/proj/production/flowcells/hiseqx/180907_ST-E00269_0299_AHNYKJCCXY/`

**Expected outcome**:
demux should start without errors.

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @ingkebil 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because no new functionality was added.
