### PR TITLE
fix: run once and only once

### DIFF
--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -70,6 +70,9 @@ for RUN_DIR in ${IN_DIR}/*; do
                 log "date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/demuxcomplete.txt"
                 date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/demuxcomplete.txt
             fi
+
+            # This is an easy way to avoid running multiple demuxes at the same time
+            break
         else
             log "${RUN} is finished and demultiplexing has already started"
         fi


### PR DESCRIPTION
This PR removes a run condition from starting a novaseq demux

**How to test**:
- get two run folders ready by removing the demuxstarted.txt
- modify the checkfornewrun.bash script by not really calling the demux-novaseq.bash script, rather just echo that it was called (to avoid actually to have to demux)
- run checkfornewrun.bash 

**Expected outcome**:
Only one run should "start" (echo)

**Review:**
- [x] code approved by @patrikgrenfeldt  
- [x] tests executed by @ingkebil 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because this fixes an edge case bug.
