### PR TITLE
Use correct basemask for demultiplexing NIPT runs from the NovaSeq

### DIFF
--- a/scripts/novaseq/demux-novaseq.bash
+++ b/scripts/novaseq/demux-novaseq.bash
@@ -41,12 +41,11 @@ ${BCL2FASTQ_BIN} --version
 # Here we go!
 log "Here we go!"
 
-BASEMASK=Y151,I10,I10,Y151
-UNALIGNED_DIR=Unaligned-${BASEMASK//,}
+UNALIGNED_DIR=Unaligned
 
 # DEMUX !
-log "${BCL2FASTQ_BIN} --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${IN_DIR} --output-dir ${OUT_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${IN_DIR}/SampleSheet.csv --barcode-mismatches 1"
-${BCL2FASTQ_BIN} --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${IN_DIR} --output-dir ${OUT_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${IN_DIR}/SampleSheet.csv --barcode-mismatches 1
+log "${BCL2FASTQ_BIN} --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${IN_DIR} --output-dir ${OUT_DIR}/${UNALIGNED_DIR} --sample-sheet ${IN_DIR}/SampleSheet.csv --barcode-mismatches 1"
+${BCL2FASTQ_BIN} --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${IN_DIR} --output-dir ${OUT_DIR}/${UNALIGNED_DIR} --sample-sheet ${IN_DIR}/SampleSheet.csv --barcode-mismatches 1
 
 # add samplesheet to unaligned folder
 cp ${IN_DIR}/SampleSheet.csv ${OUT_DIR}/${UNALIGNED_DIR}/


### PR DESCRIPTION
This PR enables NIPT NovaSeq run to be demultiplexed with the correct basemask.

**How to test**:
1.  tbd.

**Expected outcome**:
Demultiplexing should finish without errors.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
