### PR TITLE
Fix empty samplesheet

### DIFF
--- a/demux/basemask.py
+++ b/demux/basemask.py
@@ -1,20 +1,21 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import click
 import logging
 
-from path import Path
+from pathlib import Path
 import xml.etree.cElementTree as et
 
-from .utils import Samplesheet, HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet, MiseqSamplesheet
+from .utils import HiSeqXSamplesheet, NIPTSamplesheet, HiSeq2500Samplesheet, MiseqSamplesheet
 
 log = logging.getLogger(__name__)
+
 
 @click.group()
 def basemask():
     """Samplesheet commands"""
     pass
+
 
 @basemask.command()
 @click.argument('rundir')
@@ -34,14 +35,13 @@ def create(rundir, lane, application):
     elif application == 'wgs':
         sheet = HiSeqXSamplesheet(samplesheet)
 
-
     # runParameters.xml
     run_params_tree = et.parse(Path(rundir).joinpath('runParameters.xml'))
     read1_len = int(run_params_tree.findtext('Setup/IndexRead1'))
     read2_len = int(run_params_tree.findtext('Setup/IndexRead2'))
 
     lines = [line for line in sheet.lines_per_column('lane', lane)]
-    
+
     # get the inex lengths
     index1 = lines[0]['index']
     index2 = lines[0]['index2'] if 'index2' in lines[0] else ''

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -83,11 +83,12 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         """ Only keeps the first part of the project name"""
         return project.split(' ')[0]
 
+    # import ipdb; ipdb.set_trace()
     lims_api = ClinicalLims(**context.obj['lims'])
     raw_samplesheet = list(lims_api.samplesheet(flowcell))
 
     if len(raw_samplesheet) == 0:
-        sys.stderr.write('Samplesheet not found in LIMS!')
+        sys.stderr.write(f'Samplesheet for {flowcell} not found in LIMS! ')
         context.abort()
 
     if longest:

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -83,7 +83,6 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
         """ Only keeps the first part of the project name"""
         return project.split(' ')[0]
 
-    # import ipdb; ipdb.set_trace()
     lims_api = ClinicalLims(**context.obj['lims'])
     raw_samplesheet = list(lims_api.samplesheet(flowcell))
 

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -87,7 +87,7 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
     raw_samplesheet = list(lims_api.samplesheet(flowcell))
 
     if len(raw_samplesheet) == 0:
-        log.error('Samplesheet not found in LIMS!')
+        sys.stderr.write('Samplesheet not found in LIMS!')
         context.abort()
 
     if longest:

--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -87,7 +87,7 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
     raw_samplesheet = list(lims_api.samplesheet(flowcell))
 
     if len(raw_samplesheet) == 0:
-        click.echo(click.style('Samplesheet not found in LIMS!', fg='red'))
+        log.error('Samplesheet not found in LIMS!')
         context.abort()
 
     if longest:

--- a/demux/utils/samplesheet.py
+++ b/demux/utils/samplesheet.py
@@ -1,8 +1,7 @@
 import re
-from time import strftime
 from copy import deepcopy
 from collections import OrderedDict
-from path import Path
+from pathlib import Path
 
 
 class SampleSheetValidationException(Exception):
@@ -21,6 +20,7 @@ class SampleSheetParsexception(Exception):
 
 class Line(dict):
 
+    @staticmethod
     def _reverse_complement(dna):
         complement = {'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A'}
         return ''.join([complement[base] for base in dna[::-1]])
@@ -28,7 +28,7 @@ class Line(dict):
     @property
     def dualindex(self, delim='-', revcomp=False):
         if 'index2' in self and len(self['index2']):
-            index2 = _reverse_complement(self['index2']) if revcomp else self['index2']
+            index2 = self._reverse_complement(self['index2']) if revcomp else self['index2']
             return self['index'] + delim + index2
         return self['index']
 

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -50,8 +50,6 @@ for RUN_DIR in ${IN_DIR}/*; do
 
     if [[ -f ${RUN_DIR}/RTAComplete.txt ]]; then
         if [[ ! -f ${RUN_DIR}/demuxstarted.txt ]]; then
-            log "date +'%Y%m%d%H%M%S' > ${RUN_DIR}/demuxstarted.txt"
-            date +'%Y%m%d%H%M%S' > ${RUN_DIR}/demuxstarted.txt
 
 	    # remove empty sample sheets before continuing
 	    if [[ ! -s ${RUN_DIR}/SampleSheet.csv ]]; then
@@ -65,6 +63,9 @@ for RUN_DIR in ${IN_DIR}/*; do
 
             log "mkdir -p ${DEMUXES_DIR}/${RUN}/"
             mkdir -p ${DEMUXES_DIR}/${RUN}/
+
+            log "date +'%Y%m%d%H%M%S' > ${RUN_DIR}/demuxstarted.txt"
+            date +'%Y%m%d%H%M%S' > ${RUN_DIR}/demuxstarted.txt
 
             log "bash ${SCRIPT_DIR}/demux-novaseq.bash ${RUN_DIR} ${DEMUXES_DIR} &>> ${PROJECTLOG}"
             bash ${SCRIPT_DIR}/demux-novaseq.bash ${RUN_DIR} ${DEMUXES_DIR} &>> ${PROJECTLOG}

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -58,7 +58,7 @@ for RUN_DIR in ${IN_DIR}/*; do
 
             if [[ ! -e ${RUN_DIR}/SampleSheet.csv ]]; then
                 log "demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 2>>${PROJECTLOG}"
-		demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 2>>${PROJECTLOG} 
+                demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 2>>${PROJECTLOG} 
             fi
 
             log "mkdir -p ${DEMUXES_DIR}/${RUN}/"

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -57,7 +57,7 @@ for RUN_DIR in ${IN_DIR}/*; do
             fi
 
             if [[ ! -e ${RUN_DIR}/SampleSheet.csv ]]; then
-                log "demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv"
+                log "demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 2>>${PROJECTLOG}"
 		demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 2>>${PROJECTLOG} 
             fi
 

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -53,7 +53,7 @@ for RUN_DIR in ${IN_DIR}/*; do
 
 	    # remove empty sample sheets before continuing
 	    if [[ ! -s ${RUN_DIR}/SampleSheet.csv && -e ${RUN_DIR}/SampleSheet.csv ]]; then
-		rm ${RUN_DIR}/SampleSheet.csv
+                rm ${RUN_DIR}/SampleSheet.csv
 	    fi
 
             if [[ ! -e ${RUN_DIR}/SampleSheet.csv ]]; then

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -51,10 +51,10 @@ for RUN_DIR in ${IN_DIR}/*; do
     if [[ -f ${RUN_DIR}/RTAComplete.txt ]]; then
         if [[ ! -f ${RUN_DIR}/demuxstarted.txt ]]; then
 
-	    # remove empty sample sheets before continuing
-	    if [[ ! -s ${RUN_DIR}/SampleSheet.csv && -e ${RUN_DIR}/SampleSheet.csv ]]; then
+            # remove empty sample sheets before continuing
+            if [[ ! -s ${RUN_DIR}/SampleSheet.csv && -e ${RUN_DIR}/SampleSheet.csv ]]; then
                 rm ${RUN_DIR}/SampleSheet.csv
-	    fi
+            fi
 
             if [[ ! -e ${RUN_DIR}/SampleSheet.csv ]]; then
                 log "demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv"

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -58,7 +58,7 @@ for RUN_DIR in ${IN_DIR}/*; do
 
             if [[ ! -e ${RUN_DIR}/SampleSheet.csv ]]; then
                 log "demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv"
-                demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv
+		demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 2>>${PROJECTLOG} 
             fi
 
             log "mkdir -p ${DEMUXES_DIR}/${RUN}/"

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -52,7 +52,7 @@ for RUN_DIR in ${IN_DIR}/*; do
         if [[ ! -f ${RUN_DIR}/demuxstarted.txt ]]; then
 
             # start with a clean slate: remove empty sample sheets before continuing
-            if [[ ! -s ${RUN_DIR}/SampleSheet.csv && -e ${RUN_DIR}/SampleSheet.csv ]]; then
+            if [[ ! -s ${RUN_DIR}/SampleSheet.csv  ]]; then
                 rm ${RUN_DIR}/SampleSheet.csv
             fi
 

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -52,7 +52,7 @@ for RUN_DIR in ${IN_DIR}/*; do
         if [[ ! -f ${RUN_DIR}/demuxstarted.txt ]]; then
 
 	    # remove empty sample sheets before continuing
-	    if [[ ! -s ${RUN_DIR}/SampleSheet.csv ]]; then
+	    if [[ ! -s ${RUN_DIR}/SampleSheet.csv && -e ${RUN_DIR}/SampleSheet.csv ]]; then
 		rm ${RUN_DIR}/SampleSheet.csv
 	    fi
 

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -51,14 +51,20 @@ for RUN_DIR in ${IN_DIR}/*; do
     if [[ -f ${RUN_DIR}/RTAComplete.txt ]]; then
         if [[ ! -f ${RUN_DIR}/demuxstarted.txt ]]; then
 
-            # remove empty sample sheets before continuing
+            # start with a clean slate: remove empty sample sheets before continuing
             if [[ ! -s ${RUN_DIR}/SampleSheet.csv && -e ${RUN_DIR}/SampleSheet.csv ]]; then
                 rm ${RUN_DIR}/SampleSheet.csv
             fi
 
             if [[ ! -e ${RUN_DIR}/SampleSheet.csv ]]; then
-                log "demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 2>>${PROJECTLOG}"
-                demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 2>>${PROJECTLOG} 
+                log "demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv"
+                demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 
+            fi
+
+	    # exit if samplesheet is still empty after running demux sheet fetch
+            if [[ ! -s ${RUN_DIR}/SampleSheet.csv && -e ${RUN_DIR}/SampleSheet.csv ]]; then
+                echo "Sample sheet empty! Exiting!" 1>&2
+                continue
             fi
 
             log "mkdir -p ${DEMUXES_DIR}/${RUN}/"

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -62,7 +62,7 @@ for RUN_DIR in ${IN_DIR}/*; do
             fi
 
             # exit if samplesheet is still empty after running demux sheet fetch
-            if [[ ! -s ${RUN_DIR}/SampleSheet.csv && -e ${RUN_DIR}/SampleSheet.csv ]]; then
+            if [[ ! -s ${RUN_DIR}/SampleSheet.csv ]]; then
                 echo "Sample sheet empty! Exiting!" 1>&2
                 continue
             fi

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -53,6 +53,11 @@ for RUN_DIR in ${IN_DIR}/*; do
             log "date +'%Y%m%d%H%M%S' > ${RUN_DIR}/demuxstarted.txt"
             date +'%Y%m%d%H%M%S' > ${RUN_DIR}/demuxstarted.txt
 
+	    # remove empty sample sheets before continuing
+	    if [[ ! -s ${RUN_DIR}/SampleSheet.csv ]]; then
+		rm ${RUN_DIR}/SampleSheet.csv
+	    fi
+
             if [[ ! -e ${RUN_DIR}/SampleSheet.csv ]]; then
                 log "demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv"
                 demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv

--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -61,7 +61,7 @@ for RUN_DIR in ${IN_DIR}/*; do
                 demux sheet fetch --application nova --pad --longest ${FC} > ${RUN_DIR}/SampleSheet.csv 
             fi
 
-	    # exit if samplesheet is still empty after running demux sheet fetch
+            # exit if samplesheet is still empty after running demux sheet fetch
             if [[ ! -s ${RUN_DIR}/SampleSheet.csv && -e ${RUN_DIR}/SampleSheet.csv ]]; then
                 echo "Sample sheet empty! Exiting!" 1>&2
                 continue


### PR DESCRIPTION
This PR fixes production deviation #129 where demultiplexing failed due to an empty sample sheet in one of the runs directories.

**How to prepare for test**:
- [x] ssh to thalamus
- [x] install on stage:
`bash servers/resources/clinical-preproc.scilifelab.se/update-demux-stage.sh fix-empty-samplesheet`
- [x] in `checkfornewrun.bash`, uncomment line 7: `source ~/.aliases`, else the demux alias is set to the PROD version!

**How to test**:

#### TC1: fetch samplesheet for flowcell HW2C7DSXX from LIMS
- [x] on thalamus create empty folder `/home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX`
- [x] `touch /home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX/RTAComplete.txt`
- [x] remove `/home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX/demuxstarted.txt` if present.
- [x] run `bash /home/hiseq.clinical/STAGE/SCRIPTS/git/demultiplexing/scripts/novaseq/checkfornewrun.bash /home/hiseq.clinical/STAGE/novaseq/runs/ /home/hiseq.clinical/STAGE/novaseq/demux/`

**Expected test outcome**:
- [x] check that a correct samplesheet has been created in `/home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX`
- [x] Take a screenshot and attach or copy/paste the output.


#### TC2: samplesheet for flowcell HW2C7DSXX already exists, skip fetching from LIMS
- [x] on thalamus create empty folder `/home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX`
- [x] `touch /home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX/RTAComplete.txt`
- [x] `touch /home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX/SampleSheet.csv`
- [x] `echo "I'm not empty" > /home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX/SampleSheet.csv`
- [x] remove `/home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX/demuxstarted.txt` if present.
- [x] run `bash /home/hiseq.clinical/STAGE/SCRIPTS/git/demultiplexing/scripts/novaseq/checkfornewrun.bash /home/hiseq.clinical/STAGE/novaseq/runs/ /home/hiseq.clinical/STAGE/novaseq/demux/`

**Expected test outcome**:
- [x] The script will not fetch a new sample sheet from LIMS since a non-empy sample sheet exists.
- [x] Take a screenshot and attach or copy/paste the output.

#### TC3: samplesheet for flowcell HW2C7DSXX already exists but is EMPTY!
- [x] on thalamus create empty folder `/home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX`
- [x] `touch /home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX/RTAComplete.txt`
- [x] `touch /home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX/SampleSheet.csv`
- [x] remove `/home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XHW2C7DSXX/demuxstarted.txt` if present.
- [x] run `bash /home/hiseq.clinical/STAGE/SCRIPTS/git/demultiplexing/scripts/novaseq/checkfornewrun.bash /home/hiseq.clinical/STAGE/novaseq/runs/ /home/hiseq.clinical/STAGE/novaseq/demux/`

#### TC4: samplesheet for flowcell not found in LIMS
- [x] on thalamus create empty folder `/home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XNOFLOWCELL`
- [x] `touch /home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XNOFLOWCELL/RTAComplete.txt`
- [x] remove `/home/hiseq.clinical/STAGE/novaseq/runs/test_fix_empty_samplesheet_XNOFLOWCELL/demuxstarted.txt` if present.
- [x] run `bash /home/hiseq.clinical/STAGE/SCRIPTS/git/demultiplexing/scripts/novaseq/checkfornewrun.bash /home/hiseq.clinical/STAGE/novaseq/runs/ /home/hiseq.clinical/STAGE/novaseq/demux/`
**Expected test outcome**:
- [x] The sample sheet will be empty instead of containing an error message `Samplesheet not found in LIMS!`
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @hassanfa 
- [x] tests executed by @barrystokman 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
