### PR TITLE
Fix PyYAML yaml.load(input) Deprecation

### DIFF
--- a/demux/cli/base.py
+++ b/demux/cli/base.py
@@ -20,7 +20,7 @@ def demux(context, log_level, config):
     """Making demuxing easier!"""
     setup_logging(level=log_level)
     #log.info('{}: version {}'.format(__package__, __version__))
-    context.obj = yaml.load(config) if config else {}
+    context.obj = yaml.full_load(config) if config else {}
     context.obj['log_level'] = log_level
 
 


### PR DESCRIPTION
This PR fixes PyYAML yaml.load(input) Deprecation

**How to prepare for test**:
- [x] ssh to thamalus as hiseq.clinical
- [x] install on stage:
`bash servers/resources/clinical-preproc.scilifelab.se/update-demux-stage.sh yaml-load`


**How to test**:
- [x] login to thalamus
- [x] `source activate stage`
- [x] run `demux sheet --help`

**Expected test outcome**:
- [x] check that the warning `YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.                        
  context.obj = yaml.load(config) if config else {}` does not appear
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @barrystokman 
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
