### PR TITLE
temp fix for path to dummy indices

### DIFF
--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -170,7 +170,8 @@ def fetch(context, flowcell, application, dualindex, indexlength, longest, short
 
         path = os.path.abspath(__file__)
         dir_path = os.path.dirname(path)
-        with open(f"{dir_path}/../../files/20181012_Indices.csv") as csv_file:
+        # with open(f"{dir_path}/../../files/20181012_Indices.csv") as csv_file:
+        with open(f"/home/hiseq.clinical/SCRIPTS/git/demultiplexing/files/20181012_Indices.csv") as csv_file:
             dummy_samples_csv = csv.reader(csv_file, delimiter=',')
             dummy_samples = [row for row in dummy_samples_csv]
             added_dummy_samples = []


### PR DESCRIPTION
This PR adds/fixes:

![image](https://user-images.githubusercontent.com/26384108/89003873-2ce73780-d301-11ea-9185-c1b19928b018.png)

**How to prepare for test**:
- [x] ssh to thalamus
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-demux-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [x] login to thalamus
- [x] do `demux sheet fetch -a nova -p --longest HFNHYDSXY`


**Expected test outcome**:
- [x] check that a samplesheet is fetched from LIMS
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @barrystokman 
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [x] **MAJOR** - when you make incompatible API changes

