### PR TITLE
Check for CopyComplete.txt to prevent duplicate reads in analysis

### DIFF
--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -48,7 +48,7 @@ for RUN_DIR in ${IN_DIR}/*; do
     FC=${FC:1}
     PROJECTLOG=${DEMUXES_DIR}/${RUN}/projectlog.$(date +'%Y%m%d%H%M%S').log
 
-    if [[ -f ${RUN_DIR}/RTAComplete.txt ]]; then
+    if [[ -f ${RUN_DIR}/RTAComplete.txt && -f ${RUN_DIR}/CopyComplete.txt]]; then
         if [[ ! -f ${RUN_DIR}/demuxstarted.txt ]]; then
 
             # start with a clean slate: remove empty sample sheets before continuing


### PR DESCRIPTION
If we start demultiplexing when the file `CopyComplete.txt` is present, we prevent the demultiplexing from starting before syncing is fully complete.

This prevents duplicate reads from showing up due to temporary bcl files still being present, but also prevents demultiplexing failing due to missing/corrupted bcl files caused by a lag in the syncing from sequencer -> NAS -> thalamus. Two birds with one stone.

`RTAComplete.txt` indicates that all the bcl have been created *on the sequencer* for a particular run
`CopyComplete.txt` indicates that all data has been synced to the NAS from the sequencer, and the tmp bcl files have been removed.

Why did we only check for `RTAComplete.txt`?

1) the use of `CopyComplete.txt` was added as a feature at a later stage (only several years ago /s)
2) it was never a problem before to use `RTAComplete.txt` as a trigger to start demultiplexing.

Presumably something changed the transfer from sequencer -> NAS -> thalamus after the NAS upgrades.

**How to prepare for test**:

**How to test**:

**Expected test outcome**:

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
