### PR TITLE
feat(docker): Adds a bcl2fastq docker recipe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,12 @@ Demultiplexing adheres to [semantic versioning].
 
 Demultiplexing is using github flow branching model as described in our [development manual][development-branch-model].
 
-## Publishing to PyPi
+## Publishing
 
 Bump the version according to semantic versioning locally on branch `master` using [bumpversion]:
 
 ```
 bumpversion [major | minor | patch ]
-git push
-git push --tag
 ```
 
 Reinstall the application with the new version:
@@ -23,12 +21,20 @@ Reinstall the application with the new version:
 poetry install
 ```
 
-Build and publish:
+Build and publish to PyPi:
 
 ```
 poetry build
 poetry publish
 ```
+
+Push to git:
+```
+git push
+git push --tag
+```
+
+This will trigger a new docker build using the git release tag as name.
 
 [bumpversion]: https://github.com/c4urself/bump2version
 [development-branch-model]: http://www.clinicalgenomics.se/development/dev/models/

--- a/container/bcl2fastq/Dockerfile
+++ b/container/bcl2fastq/Dockerfile
@@ -1,0 +1,14 @@
+FROM centos:7
+
+RUN yum update -y \
+   && yum install -y unzip
+
+# Log into basespace and download the .rmp zip file. Place it in the same dir as the dockerfile
+COPY bcl2fastq2-v2-20-0-linux-x86-64.zip /tmp
+
+##### Get and install bcl2fastq
+RUN cd /tmp \
+    && unzip bcl2fastq2-v2-20-0-linux-x86-64.zip \
+    && yum install -y bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm
+RUN rm /tmp/bcl2fastq2*
+


### PR DESCRIPTION
This PR adds/fixes:

- See above

**How to prepare for test**:
- [x] ssh to hasta
- [x] Run: `cd /home/proj/development/demux-on-hasta/novaseq/container/`

**How to test**:
- [x]  Run: `singularity exec bcl2fastq_v2-20-0.sif bcl2fastq --help`

**Expected outcome**
- [x] The help text for bcl2fastq should be generated

**Review:**
- [x] code approved by BS, KN
- [x] tests executed by HS
- [x] "Merge" approved by BS, KN
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
