### PR TITLE
fix novaseq demux script to enable automated post demux actions

### DIFF
--- a/scripts/novaseq/checkfornewrun.bash
+++ b/scripts/novaseq/checkfornewrun.bash
@@ -75,10 +75,15 @@ for RUN_DIR in ${IN_DIR}/*; do
             bash ${SCRIPT_DIR}/demux-novaseq.bash ${RUN_DIR} ${DEMUXES_DIR} ${FC} ${PROJECTLOG} &>> ${PROJECTLOG}
 
             if [[ $? == 0 ]]; then
-                log "rm -f ${DEMUXES_DIR}/${RUN}/copycomplete.txt"
-                rm -f ${DEMUXES_DIR}/${RUN}/copycomplete.txt
+                # indicate demultiplexing is finished
                 log "date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/demuxcomplete.txt"
                 date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/demuxcomplete.txt
+                # create trigger file for delivery script
+                log "date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/copycomplete.txt"
+                date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/copycomplete.txt
+                # remove delivery.txt (if present) to trigger delivery
+                log "date +'%Y%m%d%H%M%S' remove delivery.txt"
+                rm -f date ${DEMUXES_DIR}/${RUN}/delivery.txt
             fi
 
             # This is an easy way to avoid running multiple demuxes at the same time

--- a/scripts/novaseq/stage/checkfornewrun.bash
+++ b/scripts/novaseq/stage/checkfornewrun.bash
@@ -76,10 +76,15 @@ for RUN_DIR in ${IN_DIR}/*; do
             bash ${SCRIPT_DIR}/demux-novaseq.bash ${RUN_DIR} ${DEMUXES_DIR} ${FC} ${PROJECTLOG} &>> ${PROJECTLOG}
 
             if [[ $? == 0 ]]; then
-                log "rm -f ${DEMUXES_DIR}/${RUN}/copycomplete.txt"
-                rm -f ${DEMUXES_DIR}/${RUN}/copycomplete.txt
+               # indicate demultiplexing is finished
                 log "date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/demuxcomplete.txt"
                 date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/demuxcomplete.txt
+                # create trigger file for delivery script
+                log "date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/copycomplete.txt"
+                date +'%Y%m%d%H%M%S' > ${DEMUXES_DIR}/${RUN}/copycomplete.txt
+                # remove delivery.txt (if present) to trigger delivery
+                log "date +'%Y%m%d%H%M%S' remove delivery.txt"
+                rm -f date ${DEMUXES_DIR}/${RUN}/delivery.txt
             fi
 
             # This is an easy way to avoid running multiple demuxes at the same time


### PR DESCRIPTION
The script https://github.com/Clinical-Genomics/deliver/blob/master/scripts/checkfornewdemuxonhasta.bash looks for both copycomplete.txt and demuxcomplete.txt to start post demux actions. For novaseq flowcells these actions are limited to adding the flowcell to HK (by running `cg transfer flowcell <flowcell_id`) and sending out an email indicating the the run is complete.

The file copycomplete.txt was previously added by the script https://github.com/Clinical-Genomics/demultiplexing/blob/98b5d9f5dff9d5bd932db98c32c3dbf422a73b11/scripts/2-hiseq-deliver.bash on thalamus that synced the demux directory on thalamus to the demultiplexed-runs directory on hasta.

This fix makes sure a copycomplete.txt is added to the run directory in demultiplexed-runs. It also remove any existing delivery.txt so the automation will pick it up for post demux actions

**How to prepare for test**:
- [x] ssh to hasta
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-demux-stage.sh fix/novaseq-hasta-delivery-fix`

**How to test**:
- [x]  remove one demuxstarted.txt: `rm /home/proj/stage/flowcells/novaseq/runs/201203_A00689_0200_AHVKJCDRXX/demuxstarted.txt
- [x] run `bash /home/proj/stage/bin/git/demultiplexing/scripts/novaseq/stage/checkfornewrun.bash /home/proj/stage/flowcells/novaseq/runs/ /home/proj/stage/demultiplexed-runs/`

**Expected test outcome**:
- [x] both `demuxcomplete.txt and copycomplete.txt` are created in `/home/proj/stage/demultiplexed-runs/201203_A00689_0200_AHVKJCDRXX`
- [x] `delivery.txt` is removed if present in `/home/proj/stage/demultiplexed-runs/201203_A00689_0200_AHVKJCDRXX`
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
