### PR TITLE
fix weirdness caused by bumpversion typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "demux"
-version = "version = "5.5.2""
+version = "5.5.2"
 description = "Application for demultiplexing sequence data"
 authors = ["henrikstranneheim <henrik.stranneheim@scilifelab.se>"]
 license = "MIT"


### PR DESCRIPTION
This PR fixes corrupted `pyproject.toml`, causing error during deployment.

**How to prepare for test**:
- [x] Install on stage.

**Expected test outcome
- [x] deployment on stage finishes without errors.

**Review:**
- [ ] code approved by
- [x] tests executed by @barrystokman 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
