### PR TITLE
fix(novaseq-bind): Add demultiplexed-runs folder to singularity bind…

### DIFF
--- a/scripts/novaseq/demux-novaseq.sh
+++ b/scripts/novaseq/demux-novaseq.sh
@@ -41,11 +41,13 @@ log "On node: $(hostname)"
 log "starting, will use ${TMPDIR}"
 log "Run directory: ${RUN_DIR}"
 log "Demux directory: ${DEMUX_DIR}"
+log "mkdir -p /home/proj/production/flowcells/novaseq/$SLURM_JOB_ID"
+mkdir -p /home/proj/production/flowcells/novaseq/"$SLURM_JOB_ID"
 
 ################
 # RUN BCL2FASTQ#
 ################
 
 log "start demultiplexing ${RUN_DIR}"
-log "singularity exec --bind /home/proj/production/flowcells/novaseq,/home/proj/production/flowcells/novaseq/"$SLURM_JOB_ID":/run/user/$(id -u) /home/proj/production/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${RUN_DIR} --output-dir ${DEMUX_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${RUN_DIR}/SampleSheet.csv --barcode-mismatches 1"
-singularity exec --bind /home/proj/production/flowcells/novaseq,/home/proj/production/flowcells/novaseq/"$SLURM_JOB_ID":/run/user/$(id -u) /home/proj/production/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${RUN_DIR} --output-dir ${DEMUX_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${RUN_DIR}/SampleSheet.csv --barcode-mismatches 1
+log "singularity exec --bind /home/proj/production/demultiplexed-runs,/home/proj/production/flowcells/novaseq,/home/proj/production/flowcells/novaseq/"$SLURM_JOB_ID":/run/user/$(id -u) /home/proj/production/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${RUN_DIR} --output-dir ${DEMUX_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${RUN_DIR}/SampleSheet.csv --barcode-mismatches 1"
+singularity exec --bind /home/proj/production/demultiplexed-runs,/home/proj/production/flowcells/novaseq,/home/proj/production/flowcells/novaseq/"$SLURM_JOB_ID":/run/user/$(id -u) /home/proj/production/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${RUN_DIR} --output-dir ${DEMUX_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${RUN_DIR}/SampleSheet.csv --barcode-mismatches 1

--- a/scripts/novaseq/stage/demux-novaseq.sh
+++ b/scripts/novaseq/stage/demux-novaseq.sh
@@ -42,11 +42,13 @@ log "On node: $(hostname)"
 log "starting, will use ${TMPDIR}"
 log "Run directory: ${RUN_DIR}"
 log "Demux directory: ${DEMUX_DIR}"
+log "mkdir -p /home/proj/stage/flowcells/novaseq/$SLURM_JOB_ID"
+mkdir -p /home/proj/stage/flowcells/novaseq/"$SLURM_JOB_ID"
 
 ################
 # RUN BCL2FASTQ#
 ################
 
 log "start demultiplexing ${RUN_DIR}"
-log "singularity exec --bind /home/proj/stage/flowcells/novaseq,/home/proj/stage/flowcells/novaseq/"$SLURM_JOB_ID":/run/user/$(id -u) /home/proj/stage/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${RUN_DIR} --output-dir ${DEMUX_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${RUN_DIR}/SampleSheet.csv --barcode-mismatches 1"
-singularity exec --bind /home/proj/stage/flowcells/novaseq,/home/proj/stage/flowcells/novaseq/"$SLURM_JOB_ID":/run/user/$(id -u) /home/proj/stage/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${RUN_DIR} --output-dir ${DEMUX_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${RUN_DIR}/SampleSheet.csv --barcode-mismatches 1
+log "singularity exec --bind /home/proj/stage/demultiplexed-runs,/home/proj/stage/flowcells/novaseq,/home/proj/stage/flowcells/novaseq/"$SLURM_JOB_ID":/run/user/$(id -u) /home/proj/stage/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${RUN_DIR} --output-dir ${DEMUX_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${RUN_DIR}/SampleSheet.csv --barcode-mismatches 1"
+singularity exec --bind /home/proj/stage/demultiplexed-runs,/home/proj/stage/flowcells/novaseq,/home/proj/stage/flowcells/novaseq/"$SLURM_JOB_ID":/run/user/$(id -u) /home/proj/stage/demux-on-hasta/novaseq/container/bcl2fastq_v2-20-0.sif bcl2fastq --loading-threads 3 --processing-threads 15 --writing-threads 3 --runfolder-dir ${RUN_DIR} --output-dir ${DEMUX_DIR}/${UNALIGNED_DIR} --use-bases-mask ${BASEMASK} --sample-sheet ${RUN_DIR}/SampleSheet.csv --barcode-mismatches 1


### PR DESCRIPTION
This PR adds/fixes:

- Fixes https://github.com/Clinical-Genomics/IT-issues/issues/142
- Add demultiplexed-runs folder to singularity bind
- Create $SLURM_JOB_ID folder before calling container

**How to prepare for test**:
- [ ] ssh to hasta
- [ ] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-demux-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [ ] login to ...
- [ ] do ...

**Expected test outcome**:
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
