### PR TITLE
Fix carriage return in sed command in syncnipt script

### DIFF
--- a/scripts/2500/NIPT/syncnipt.bash
+++ b/scripts/2500/NIPT/syncnipt.bash
@@ -41,8 +41,7 @@ for RUN in ${RUNBASE}/*; do
 
       # transform SampleSheet from Mac/Windows to Unix
       if grep -qs $'\r' ${RUNBASE}${RUN}/SampleSheet.csv; then
-          sed -i 's/
-/\n/g' ${RUNBASE}${RUN}/SampleSheet.csv
+          sed -i 's/^M/\n/g' ${RUNBASE}${RUN}/SampleSheet.csv
       fi
       sed -i '/^$/d' ${RUNBASE}${RUN}/SampleSheet.csv
 

--- a/scripts/2500/stage/NIPT/syncnipt.bash
+++ b/scripts/2500/stage/NIPT/syncnipt.bash
@@ -41,8 +41,7 @@ for RUN in ${RUNBASE}/*; do
 
       # transform SampleSheet from Mac/Windows to Unix
       if grep -qs $'\r' ${RUNBASE}${RUN}/SampleSheet.csv; then
-          sed -i 's/
-/\n/g' ${RUNBASE}${RUN}/SampleSheet.csv
+          sed -i 's/^M/\n/g' ${RUNBASE}${RUN}/SampleSheet.csv
       fi
       sed -i '/^$/d' ${RUNBASE}${RUN}/SampleSheet.csv
 


### PR DESCRIPTION
This PR fixes the use of `^M` in a `sed` command in the script `syncnipt.bash`. `^M` stands for carriage return, in the sample sheet a carriage return needs to be replaced with a new line `\n`, and for some reason the symbol `^M` can end up as an actual hard return in the code 😡 

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
