### PR TITLE
Version check for updates to Novaseq versions

### DIFF
--- a/demux/constants/samplesheet.py
+++ b/demux/constants/samplesheet.py
@@ -1,4 +1,7 @@
 """Constants for sample sheet creation"""
+from distutils.version import LooseVersion, StrictVersion
 
 NIPT_INDEX_LENGTH = 8
-PARAMETER_TO_VERSION = {"1": 1.0, "3": 1.5}
+PARAMETER_TO_VERSION = {"1": "1.0", "3": "1.5"}
+REV_COMP_CONTROL_SOFTWARE_VERSION = StrictVersion("1.7.0")
+REV_COMP_REAGENT_KIT_VERSION = LooseVersion("1.5")

--- a/demux/utils/novaseq_samplesheet.py
+++ b/demux/utils/novaseq_samplesheet.py
@@ -133,8 +133,8 @@ class CreateNovaseqSamplesheet:
         kit version REV_COMP_REAGENT_KIT_VERSION or later, the second index should be the reverse complement
         """
         return (
-            self.control_software_version >= self.REV_COMP_CONTROL_SOFTWARE_VERSION
-            and self.reagent_kit_version >= self.REV_COMP_REAGENT_KIT_VERSION
+            self.control_software_version >= REV_COMP_CONTROL_SOFTWARE_VERSION
+            and self.reagent_kit_version >= REV_COMP_REAGENT_KIT_VERSION
         )
 
     def is_nipt_samplesheet(self) -> bool:

--- a/demux/utils/novaseq_samplesheet.py
+++ b/demux/utils/novaseq_samplesheet.py
@@ -121,8 +121,9 @@ class CreateNovaseqSamplesheet:
         """If the run used the new NovaSeq control software version (CONTROL_SOFTWARE_VERSION) and the new reagent
         kit version (REAGENT_KIT_VERSION) the second index should be the reverse complement"""
         return (
-            self.runparameters.control_software_version >= self.CONTROL_SOFTWARE_VERSION
-            and self.get_reagent_kit_version() >= self.REAGENT_KIT_VERSION
+            StrictVersion(self.runparameters.control_software_version)
+            >= self.CONTROL_SOFTWARE_VERSION
+            and LooseVersion(self.get_reagent_kit_version()) >= self.REAGENT_KIT_VERSION
         )
 
     def is_nipt_samplesheet(self) -> bool:

--- a/demux/utils/novaseq_samplesheet.py
+++ b/demux/utils/novaseq_samplesheet.py
@@ -1,19 +1,21 @@
 """ Create a samplesheet for NovaSeq flowcells """
 import csv
-import re
 import sys
 from distutils.version import StrictVersion, LooseVersion
 from typing import Any, Dict, List, Union
 
 from cglims.api import ClinicalLims
 from demux.constants.constants import COMMA, DASH, SPACE
-from demux.constants.samplesheet import NIPT_INDEX_LENGTH, PARAMETER_TO_VERSION
+from demux.constants.samplesheet import (
+    NIPT_INDEX_LENGTH,
+    PARAMETER_TO_VERSION,
+    REV_COMP_CONTROL_SOFTWARE_VERSION,
+    REV_COMP_REAGENT_KIT_VERSION,
+)
 from demux.exc import NoValidReagentKitFound
 
 from .runparameters import NovaseqRunParameters
 from .samplesheet import Samplesheet
-
-import re
 
 
 class CreateNovaseqSamplesheet:
@@ -32,8 +34,6 @@ class CreateNovaseqSamplesheet:
         "operator",
         "project",
     ]
-    CONTROL_SOFTWARE_VERSION = StrictVersion("1.7.0")
-    REAGENT_KIT_VERSION = LooseVersion("1.5")
 
     def __init__(
         self,
@@ -49,12 +49,22 @@ class CreateNovaseqSamplesheet:
         self.pad = pad
         self.runparameters = NovaseqRunParameters(self.flowcell, runs_dir)
 
-    def get_raw_samplesheet(self) -> List[Dict]:
-        raw_samplesheet = list(self.lims_api.samplesheet(self.flowcell))
-        if not raw_samplesheet:
-            sys.stderr.write(f"Samplesheet for {self.flowcell} not found in LIMS! ")
-            sys.exit()
-        return raw_samplesheet
+    @property
+    def control_software_version(self) -> StrictVersion:
+        """ Returns control software version in StrictVersion format  """
+        return StrictVersion(self.runparameters.control_software_version)
+
+    @property
+    def reagent_kit_version(self) -> LooseVersion:
+        """ Derives the reagent kit version from the run parameters """
+
+        reagent_kit_version = self.runparameters.reagent_kit_version
+        if reagent_kit_version not in PARAMETER_TO_VERSION.keys():
+            raise NoValidReagentKitFound(
+                f"Expected reagent kit version {', '.join(PARAMETER_TO_VERSION.keys())}. Found {reagent_kit_version} instead. Exiting",
+            )
+
+        return LooseVersion(PARAMETER_TO_VERSION[reagent_kit_version])
 
     @property
     def header(self) -> list:
@@ -118,12 +128,13 @@ class CreateNovaseqSamplesheet:
         return raw_samplesheet
 
     def is_reverse_complement(self) -> bool:
-        """If the run used the new NovaSeq control software version (CONTROL_SOFTWARE_VERSION) and the new reagent
-        kit version (REAGENT_KIT_VERSION) the second index should be the reverse complement"""
+        """
+        If the run used NovaSeq control software version REV_COMP_CONTROL_SOFTWARE_VERSION or later and reagent
+        kit version REV_COMP_REAGENT_KIT_VERSION or later, the second index should be the reverse complement
+        """
         return (
-            StrictVersion(self.runparameters.control_software_version)
-            >= self.CONTROL_SOFTWARE_VERSION
-            and LooseVersion(self.get_reagent_kit_version()) >= self.REAGENT_KIT_VERSION
+            self.control_software_version >= self.REV_COMP_CONTROL_SOFTWARE_VERSION
+            and self.reagent_kit_version >= self.REV_COMP_REAGENT_KIT_VERSION
         )
 
     def is_nipt_samplesheet(self) -> bool:
@@ -210,16 +221,12 @@ class CreateNovaseqSamplesheet:
 
         return index1, index2
 
-    def get_reagent_kit_version(self) -> float:
-        """ Derives the reagent kit version from the run parameters """
-
-        reagent_kit_version = self.runparameters.reagent_kit_version
-        if reagent_kit_version not in PARAMETER_TO_VERSION.keys():
-            raise NoValidReagentKitFound(
-                f"Expected reagent kit version {', '.join(PARAMETER_TO_VERSION.keys())}. Found {reagent_kit_version} instead. Exiting",
-            )
-
-        return PARAMETER_TO_VERSION[reagent_kit_version]
+    def get_raw_samplesheet(self) -> List[Dict]:
+        raw_samplesheet = list(self.lims_api.samplesheet(self.flowcell))
+        if not raw_samplesheet:
+            sys.stderr.write(f"Samplesheet for {self.flowcell} not found in LIMS! ")
+            sys.exit()
+        return raw_samplesheet
 
     def construct_samplesheet(self, delimiter=COMMA, end="\n") -> str:
         """ Construct the sample sheet """

--- a/demux/utils/novaseq_samplesheet.py
+++ b/demux/utils/novaseq_samplesheet.py
@@ -1,6 +1,8 @@
 """ Create a samplesheet for NovaSeq flowcells """
 import csv
+import re
 import sys
+from distutils.version import StrictVersion
 from typing import Any, Dict, List, Union
 
 from cglims.api import ClinicalLims
@@ -10,6 +12,8 @@ from demux.exc import NoValidReagentKitFound
 
 from .runparameters import NovaseqRunParameters
 from .samplesheet import Samplesheet
+
+import re
 
 
 class CreateNovaseqSamplesheet:
@@ -28,8 +32,8 @@ class CreateNovaseqSamplesheet:
         "operator",
         "project",
     ]
-    CONTROL_SOFTWARE_VERSION = "1.7.0"
-    REAGENT_KIT_VERSION = 1.5
+    CONTROL_SOFTWARE_VERSION = StrictVersion("1.7.0")
+    REAGENT_KIT_VERSION = StrictVersion("1.5")
 
     def __init__(
         self,

--- a/demux/utils/novaseq_samplesheet.py
+++ b/demux/utils/novaseq_samplesheet.py
@@ -2,7 +2,7 @@
 import csv
 import re
 import sys
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion, LooseVersion
 from typing import Any, Dict, List, Union
 
 from cglims.api import ClinicalLims
@@ -33,7 +33,7 @@ class CreateNovaseqSamplesheet:
         "project",
     ]
     CONTROL_SOFTWARE_VERSION = StrictVersion("1.7.0")
-    REAGENT_KIT_VERSION = StrictVersion("1.5")
+    REAGENT_KIT_VERSION = LooseVersion("1.5")
 
     def __init__(
         self,

--- a/demux/utils/novaseq_samplesheet.py
+++ b/demux/utils/novaseq_samplesheet.py
@@ -121,8 +121,7 @@ class CreateNovaseqSamplesheet:
         """If the run used the new NovaSeq control software version (CONTROL_SOFTWARE_VERSION) and the new reagent
         kit version (REAGENT_KIT_VERSION) the second index should be the reverse complement"""
         return (
-            self.runparameters.control_software_version
-            >= self.CONTROL_SOFTWARE_VERSION
+            self.runparameters.control_software_version >= self.CONTROL_SOFTWARE_VERSION
             and self.get_reagent_kit_version() >= self.REAGENT_KIT_VERSION
         )
 

--- a/demux/utils/novaseq_samplesheet.py
+++ b/demux/utils/novaseq_samplesheet.py
@@ -28,8 +28,8 @@ class CreateNovaseqSamplesheet:
         "operator",
         "project",
     ]
-    NEW_CONTROL_SOFTWARE_VERSION = "1.7.0"
-    NEW_REAGENT_KIT_VERSION = 1.5
+    CONTROL_SOFTWARE_VERSION = "1.7.0"
+    REAGENT_KIT_VERSION = 1.5
 
     def __init__(
         self,
@@ -114,12 +114,12 @@ class CreateNovaseqSamplesheet:
         return raw_samplesheet
 
     def is_reverse_complement(self) -> bool:
-        """If the run used the new NovaSeq control software version (NEW_CONTROL_SOFTWARE_VERSION) and the new reagent
-        kit version (NEW_REAGENT_KIT_VERSION) the second index should be the reverse complement"""
+        """If the run used the new NovaSeq control software version (CONTROL_SOFTWARE_VERSION) and the new reagent
+        kit version (REAGENT_KIT_VERSION) the second index should be the reverse complement"""
         return (
             self.runparameters.control_software_version
-            == self.NEW_CONTROL_SOFTWARE_VERSION
-            and self.get_reagent_kit_version() == self.NEW_REAGENT_KIT_VERSION
+            >= self.CONTROL_SOFTWARE_VERSION
+            and self.get_reagent_kit_version() >= self.REAGENT_KIT_VERSION
         )
 
     def is_nipt_samplesheet(self) -> bool:

--- a/demux/utils/runparameters.py
+++ b/demux/utils/runparameters.py
@@ -1,7 +1,6 @@
 """ Parsing of Novaseq run parameters """
 import os
 import xml.etree.cElementTree as et
-from distutils.version import StrictVersion, LooseVersion
 from pathlib import Path
 
 
@@ -35,9 +34,9 @@ class NovaseqRunParameters:
         return et.parse(Path(self.file))
 
     @property
-    def control_software_version(self) -> StrictVersion:
+    def control_software_version(self) -> str:
         """ Returns the version of the NovaSeq Control Software used """
-        return StrictVersion(self.parse_runparameters().findtext("ApplicationVersion"))
+        return self.parse_runparameters().findtext("ApplicationVersion")
 
     @property
     def index_reads(self) -> int:
@@ -45,8 +44,6 @@ class NovaseqRunParameters:
         return int(self.parse_runparameters().findtext("IndexRead1NumberOfCycles"))
 
     @property
-    def reagent_kit_version(self) -> LooseVersion:
+    def reagent_kit_version(self) -> str:
         """ Returns the version of the reagent kit used """
-        return LooseVersion(
-            self.parse_runparameters().findtext("RfidsInfo/SbsConsumableVersion")
-        )
+        return self.parse_runparameters().findtext("RfidsInfo/SbsConsumableVersion")

--- a/demux/utils/runparameters.py
+++ b/demux/utils/runparameters.py
@@ -1,7 +1,7 @@
 """ Parsing of Novaseq run parameters """
 import os
 import xml.etree.cElementTree as et
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion, LooseVersion
 from pathlib import Path
 
 
@@ -47,4 +47,6 @@ class NovaseqRunParameters:
     @property
     def reagent_kit_version(self) -> LooseVersion:
         """ Returns the version of the reagent kit used """
-        return LooseVersion(self.parse_runparameters().findtext("RfidsInfo/SbsConsumableVersion"))
+        return LooseVersion(
+            self.parse_runparameters().findtext("RfidsInfo/SbsConsumableVersion")
+        )

--- a/demux/utils/runparameters.py
+++ b/demux/utils/runparameters.py
@@ -1,7 +1,8 @@
 """ Parsing of Novaseq run parameters """
 import os
-from pathlib import Path
 import xml.etree.cElementTree as et
+from distutils.version import StrictVersion
+from pathlib import Path
 
 
 class NovaseqRunParameters:
@@ -34,9 +35,9 @@ class NovaseqRunParameters:
         return et.parse(Path(self.file))
 
     @property
-    def control_software_version(self) -> str:
+    def control_software_version(self) -> StrictVersion:
         """ Returns the version of the NovaSeq Control Software used """
-        return self.parse_runparameters().findtext("ApplicationVersion")
+        return StrictVersion(self.parse_runparameters().findtext("ApplicationVersion"))
 
     @property
     def index_reads(self) -> int:
@@ -44,6 +45,6 @@ class NovaseqRunParameters:
         return int(self.parse_runparameters().findtext("IndexRead1NumberOfCycles"))
 
     @property
-    def reagent_kit_version(self) -> str:
+    def reagent_kit_version(self) -> StrictVersion:
         """ Returns the version of the reagent kit used """
-        return self.parse_runparameters().findtext("RfidsInfo/SbsConsumableVersion")
+        return StrictVersion(self.parse_runparameters().findtext("RfidsInfo/SbsConsumableVersion"))

--- a/demux/utils/runparameters.py
+++ b/demux/utils/runparameters.py
@@ -45,6 +45,6 @@ class NovaseqRunParameters:
         return int(self.parse_runparameters().findtext("IndexRead1NumberOfCycles"))
 
     @property
-    def reagent_kit_version(self) -> StrictVersion:
+    def reagent_kit_version(self) -> LooseVersion:
         """ Returns the version of the reagent kit used """
-        return StrictVersion(self.parse_runparameters().findtext("RfidsInfo/SbsConsumableVersion"))
+        return LooseVersion(self.parse_runparameters().findtext("RfidsInfo/SbsConsumableVersion"))


### PR DESCRIPTION
Control versions and kit versions were previously checked to be a specific one. However, after discussions with @AnnaZetterlund and @barrystokman we came to the conclusion that we should check if these are at least of the same or newer version.

**How to prepare for test**:
- [x] ssh to hasta
- [x] activate stage
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-demux-stage.sh control_and_reagent_version_fix`

**How to test**:
- [x] activate stage
- [x] Connect to LIMS prod to fetch FC info
- [x] change RunParameters.xml to:
    - [x] Control software version: `1.7.5`
    - [x] Reagent kit version: `3`
- [x] do `demux -c /home/karl.nyren/demux-stage.yaml sheet fetch --application nova --pad --longest H5GL3DRXY > /home/proj/stage/flowcells/novaseq/runs/210421_A00689_0257_AH5GL3DRXY/1.7.5_3_SampleSheet.csv` 
- [x] Ensure reverse complement i applied
- [x] change RunParameters.xml to:
    - [x] Control software version: `1.6.5`
    - [x] Reagent kit version: `3`
- [x] do `demux -c /home/karl.nyren/demux-stage.yaml sheet fetch --application nova --pad --longest H5GL3DRXY > /home/proj/stage/flowcells/novaseq/runs/210421_A00689_0257_AH5GL3DRXY/1.6.5_3_SampleSheet.csv`
- [x] Ensure reverse complement is not applied
- [x] change RunParameters.xml to:
    - [x] Control software version: `1.7.5`
    - [x] Reagent kit version: `1`
- [x] do `demux -c /home/karl.nyren/demux-stage.yaml sheet fetch --application nova --pad --longest H5GL3DRXY > /home/proj/stage/flowcells/novaseq/runs/210421_A00689_0257_AH5GL3DRXY/1.7.5_1_SampleSheet.csv` 
- [x] Ensure reverse complement is not applied

**Expected test outcome**:
- [ ] check that:
    - [x] There is a difference in all rows of a non-reverse complemented index SampleSheet.csv and a reverse complemented one
    - [x] There is no difference of a non-reverse complemented index SampleSheet.csv and another non-reverse complemented one
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @karlnyr 
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
