### PR TITLE
Count read cycles from runParameters.xml

### DIFF
--- a/demux/cli/basemask.py
+++ b/demux/cli/basemask.py
@@ -60,7 +60,7 @@ def create(rundir, lane, application):
 
         # index2 basemask
         if indexread2 == 0:
-            click.echo(f"Y151,{basemask_index1},Y151")
+            click.echo(f"{read1},{basemask_index1},{read2}")
         else:
             index2_n = "n" * (indexread2 - len(index2))
             if len(index2) > 0:


### PR DESCRIPTION
Read cycles for HiSeqX was hardcoded, this pr makes it so that it is determined from runParameters.xml

**How to prepare for test**:
- [x] ssh to hasta
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-demux-stage.sh fix-hiseqx-basemask-read-cycles`

**How to test**:
- [x] demux basemask create --lane 2 --application wgs /home/proj/stage/flowcells/hiseqx/150119_D00450_0151_AHB1T6ADXX

**Expected test outcome**:
- [x] The basemask generated is `Y101,I6n,Y101`
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by @karlnyr  
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
