### PR TITLE
Add Y to base mask

### DIFF
--- a/demux/cli/basemask.py
+++ b/demux/cli/basemask.py
@@ -60,7 +60,7 @@ def create(rundir, lane, application):
 
         # index2 basemask
         if indexread2 == 0:
-            click.echo(f"{read1},{basemask_index1},{read2}")
+            click.echo(f"Y{read1},{basemask_index1},Y{read2}")
         else:
             index2_n = "n" * (indexread2 - len(index2))
             if len(index2) > 0:


### PR DESCRIPTION
Updating the base mask as we get an error message in demultiplexing right now:
```"UseBasesMask formatting error. Use base mask must start with either a 'y', 'i', or 'n'. Use base mask: '151'".```


**How to prepare for test**:
- [x] ssh to hasta
- [x] paxa
- [x] install on stage:
`bash /home/proj/stage/servers/resources/hasta.scilifelab.se/update-demux-stage.sh Add-Y-to-base-mask`

**How to test**:
- [x] demux basemask create -l 8 -a wgs /home/proj/stage/flowcells/hiseqx/181130_ST-E00269_0322_AHVCFMCCXY/

**Expected test outcome**:
- [x] check that the generated base mask is Y151,I8,Y151
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @barrystokman 
- [x] tests executed by @moahaegglund 
- [x] "Merge and deploy" approved by @barrystokman 
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
