### PR TITLE
Removing linking of pooled HiSeqX Undermined fastq-files

### DIFF
--- a/scripts/hiseqx/xdemuxtiles.batch
+++ b/scripts/hiseqx/xdemuxtiles.batch
@@ -141,17 +141,6 @@ for PROJECT_DIR in "${TMPOUT_DIR}"/*; do
          cp -rl "${PROJECT_DIR}"/* "${PROJECT_OUTDIR}"
 done
 
-# Link Undetermined reads to a separate directory
-
-log "Creating Undetermined directory"
-log "mkdir -p '${UNDETERMINED_DIR}'"
-mkdir -p "${UNDETERMINED_DIR}"
-for UNDETERMINED_FASTQ_FILE in "${TMPOUT_DIR}"/Undetermined*.fastq.gz; do
-  UNDETERMINED_FASTQ=$(basename "${UNDETERMINED_FASTQ_FILE}")
-  log "ln '${UNDETERMINED_FASTQ_FILE}' '${UNDETERMINED_DIR}/${FC}-${LANE_TILE}_${UNDETERMINED_FASTQ}'"
-       ln "${UNDETERMINED_FASTQ_FILE}" "${UNDETERMINED_DIR}/${FC}-${LANE_TILE}_${UNDETERMINED_FASTQ}"
-done
-
 log "Done copying output"
 
 ############


### PR DESCRIPTION
This PR removes Undetermined files from HiSeqX demultiplexing output. This saves space since these old undetermined files where never used.

**How to prepare for test**:
- [ ] ssh to hasta
- [ ] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-demux-stage.sh hiseqx-never-link-pooled-undetermined`

**How to test**:
- [ ] login to hasta
- [ ] do something with HFH5HALXX

**Expected test outcome**:
- [ ] check that magic happened with HFH5HALXX
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by @karlnyr 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
