### PR TITLE
fix(removed --end option)

### DIFF
--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -101,7 +101,6 @@ def demux(samplesheet: str, application: str, flowcell: str):
 @click.option(
     "-d", "--delimiter", default=COMMA, show_default=True, help="column delimiter"
 )
-@click.option("-e", "--end", default="\n", show_default=True, help="line delimiter")
 @click.option(
     "-i",
     "--dualindex",


### PR DESCRIPTION
This PR fixes a bug implemented by https://github.com/Clinical-Genomics/demultiplexing/pull/153/files. The variable was removed since it was not used in the code but the `click.option` remained. 

**How to prepare for test**:
- [x] ssh to hasta
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-demux-stage.sh fix/remove-end-option`

**How to test**:
- [x] login to `hasta`
- [x] do `us`
- [x] do `demux sheet fetch -a wgs  HN7MKCCXX`

**Expected test outcome**:
- [x] check that the command does not break.
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by @karlnyr 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
