### PR TITLE
Hiseqx never link pooled undetermined

### DIFF
--- a/demux/cli/samplesheet.py
+++ b/demux/cli/samplesheet.py
@@ -59,7 +59,7 @@ def massage(samplesheet: str) -> None:
 @sheet.command()
 @click.argument("sample", type=str)
 @ARGUMENT_SAMPLE_SHEET
-def sample_in_pooled_lane(samplesheet: str, sample: str) -> None:
+def sample_in_pooled_lane(sample: str, samplesheet: str) -> None:
     """Check if a sample is in a pooled lane"""
     sample_sheet = Samplesheet(samplesheet)
 

--- a/scripts/hiseqx/xdemuxtiles.batch
+++ b/scripts/hiseqx/xdemuxtiles.batch
@@ -117,7 +117,7 @@ for PROJECT_DIR in "${TMPOUT_DIR}"/*; do
         done
 
         # Get info if lane is pooled
-        POOLED_LANE=$(demux sheet sample_in_pooled_lane "${RUNDIR}/SampleSheet.csv" "${SAMPLE_NAME}")
+        POOLED_LANE=$(demux sheet sample_in_pooled_lane "${SAMPLE_NAME}" "${RUNDIR}/SampleSheet.csv")
         # Undetermined, if not pooled link to samples
         if [[ ${POOLED_LANE} == "false" ]];
         then

--- a/scripts/hiseqx/xdemuxtiles.batch
+++ b/scripts/hiseqx/xdemuxtiles.batch
@@ -141,17 +141,6 @@ for PROJECT_DIR in "${TMPOUT_DIR}"/*; do
          cp -rl "${PROJECT_DIR}"/* "${PROJECT_OUTDIR}"
 done
 
-# Link Undetermined reads to a separate directory
-
-log "Creating Undetermined directory"
-log "mkdir -p '${UNDETERMINED_DIR}'"
-mkdir -p "${UNDETERMINED_DIR}"
-for UNDETERMINED_FASTQ_FILE in "${TMPOUT_DIR}"/Undetermined*.fastq.gz; do
-  UNDETERMINED_FASTQ=$(basename "${UNDETERMINED_FASTQ_FILE}")
-  log "ln '${UNDETERMINED_FASTQ_FILE}' '${UNDETERMINED_DIR}/${FC}-${LANE_TILE}_${UNDETERMINED_FASTQ}'"
-       ln "${UNDETERMINED_FASTQ_FILE}" "${UNDETERMINED_DIR}/${FC}-${LANE_TILE}_${UNDETERMINED_FASTQ}"
-done
-
 log "Done copying output"
 
 ############


### PR DESCRIPTION
This PR actually does what should have been done in https://github.com/Clinical-Genomics/demultiplexing/pull/158

**How to prepare for test**:
- [x] ssh to hasta
- [x] install on stage:
`bash servers/resources/hasta.scilifelab.se/update-demux-stage.sh hiseqx-never-link-pooled-undetermined`

**How to test**:
- [x] Same as in  https://github.com/Clinical-Genomics/demultiplexing/pull/158

**Expected test outcome**:
- [x] Check that no undetermined files are linked
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by @karlnyr 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
